### PR TITLE
Add pgvector semantic embeddings as 4th matching signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Response:
 
 ### One-click deploy
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,OPENAI_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20OPENAI_API_KEY%3A%20For%20semantic%20embeddings%20(optional%20but%20recommended).%20CRON_SECRET%3A%20Bearer%20token%20for%20the%20daily%20cron%20job.&project-name=agent-404&repository-name=agent-404)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,EMBEDDING_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20EMBEDDING_API_KEY%3A%20For%20semantic%20embeddings%20(optional%20but%20recommended).%20CRON_SECRET%3A%20Bearer%20token%20for%20the%20daily%20cron%20job.&project-name=agent-404&repository-name=agent-404)
 
 Click the button above and provide the required environment variables:
 - **`POSTGRES_URL`** — Connection string for a Neon or Vercel Postgres database
-- **`OPENAI_API_KEY`** — For semantic embeddings (optional but recommended, ~$0.02/1M tokens)
+- **`EMBEDDING_API_KEY`** — For semantic embeddings (optional but recommended, ~$0.02/1M tokens)
 - **`CRON_SECRET`** — Bearer token to authenticate the daily cron job
 
 After deploying, run the migration:
@@ -109,7 +109,7 @@ npm install
 # 3. Set environment variables
 #    Create .env.local with:
 #      POSTGRES_URL=postgres://...
-#      OPENAI_API_KEY=sk-...      (optional)
+#      EMBEDDING_API_KEY=sk-...      (optional)
 #      CRON_SECRET=your-secret
 
 # 4. Run migrations

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ The script detects 404 pages using (in order):
 
 ### Fuzzy Matching
 
-Suggestions are ranked using three signals:
+Suggestions are ranked using four signals:
 - **Path segment similarity** — Jaccard similarity on URL segments, version-tolerant (`v2` → `v3` = partial match)
 - **Levenshtein distance** — catches typos and minor path differences
 - **Keyword overlap** — matches words from the dead URL against page titles and headings
+- **Semantic embeddings** — cosine similarity on OpenAI `text-embedding-3-small` vectors, catches URLs with zero lexical overlap but same meaning (e.g. `/docs/authentication` → `/guides/security/oauth`)
+
+When embeddings are unavailable (no API key or API down), the system gracefully falls back to the first three signals.
 
 ## API
 
@@ -77,35 +80,56 @@ Response:
 
 ## Self-hosting
 
+### One-click deploy
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,OPENAI_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20OPENAI_API_KEY%3A%20For%20semantic%20embeddings%20(optional%20but%20recommended).%20CRON_SECRET%3A%20Bearer%20token%20for%20the%20daily%20cron%20job.&project-name=agent-404&repository-name=agent-404)
+
+Click the button above and provide the required environment variables:
+- **`POSTGRES_URL`** — Connection string for a Neon or Vercel Postgres database
+- **`OPENAI_API_KEY`** — For semantic embeddings (optional but recommended, ~$0.02/1M tokens)
+- **`CRON_SECRET`** — Bearer token to authenticate the daily cron job
+
+After deploying, run the migration:
 ```bash
+npm run db:migrate
+```
+
+### Manual setup
+
+```bash
+# 1. Fork and clone the repo
+git clone https://github.com/bharath31/agent-404.git
+cd agent-404
 npm install
 
-# Set up Vercel Postgres
-# 1. Create a Postgres database in Vercel Dashboard → Storage
-# 2. Link it to your project
-# 3. Pull env vars:
-vercel env pull .env.local
+# 2. Create a Postgres database
+#    Option A: Vercel Dashboard → Storage → Create Postgres
+#    Option B: Create a Neon database at neon.tech
 
-# Run migration
+# 3. Set environment variables
+#    Create .env.local with:
+#      POSTGRES_URL=postgres://...
+#      OPENAI_API_KEY=sk-...      (optional)
+#      CRON_SECRET=your-secret
+
+# 4. Run migrations
 npm run db:migrate
 
-# Local dev
+# 5. Local dev
 npm run dev
 
-# Build client script
+# 6. Build client script
 npm run build:script
 
-# Deploy
+# 7. Deploy
 vercel --prod
-
-# Tests
-npm test
 ```
 
 ## Stack
 
 - **Runtime**: Vercel Edge Functions (Hono)
-- **Database**: Vercel Postgres (Neon)
+- **Database**: Vercel Postgres (Neon) + pgvector
+- **Embeddings**: OpenAI `text-embedding-3-small` (256d)
 - **Client**: Vanilla JS, <3KB
 - **Indexing**: Sitemap.xml crawl + client-side beacons
 

--- a/migrations/0002_pgvector.sql
+++ b/migrations/0002_pgvector.sql
@@ -1,0 +1,8 @@
+-- Enable pgvector extension
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Add embedding column to pages
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS embedding vector(256);
+
+-- HNSW index for cosine similarity search
+CREATE INDEX IF NOT EXISTS idx_pages_embedding ON pages USING hnsw (embedding vector_cosine_ops);

--- a/migrations/run.ts
+++ b/migrations/run.ts
@@ -32,8 +32,8 @@ function splitStatements(text: string): string[] {
 	return results;
 }
 
-async function run() {
-	const raw = readFileSync(resolve(__dirname, "0001_init.sql"), "utf-8");
+async function runFile(filename: string) {
+	const raw = readFileSync(resolve(__dirname, filename), "utf-8");
 	// Strip line comments
 	const migration = raw.replace(/--.*$/gm, "");
 	const statements = splitStatements(migration);
@@ -43,8 +43,16 @@ async function run() {
 		console.log(`Running: ${preview}...`);
 		await sql.query(stmt);
 	}
+}
 
-	console.log("Migration complete.");
+async function run() {
+	const migrations = ["0001_init.sql", "0002_pgvector.sql"];
+	for (const file of migrations) {
+		console.log(`\nRunning migration: ${file}`);
+		await runFile(file);
+	}
+
+	console.log("\nAll migrations complete.");
 	process.exit(0);
 }
 

--- a/src/api/routes/suggest.ts
+++ b/src/api/routes/suggest.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { PostgresStorage } from "../../storage/postgres.js";
 import { findSuggestions } from "../../engine/matcher.js";
+import { generateDeadUrlEmbedding } from "../../engine/embeddings.js";
 
 type Env = { Variables: { storage: PostgresStorage; siteId: string } };
 
@@ -16,8 +17,18 @@ suggest.post("/", async (c) => {
 		return c.json({ error: "url is required" }, 400);
 	}
 
-	const pages = await storage.getPages(siteId);
-	const suggestions = findSuggestions(body.url, pages);
+	// Generate embedding for the dead URL
+	const deadUrlEmbedding = await generateDeadUrlEmbedding(body.url);
+
+	// Use vector pre-filter if embedding available, otherwise fall back to full scan
+	let pages;
+	if (deadUrlEmbedding) {
+		pages = await storage.searchByEmbedding(siteId, deadUrlEmbedding, 20);
+	} else {
+		pages = await storage.getPages(siteId);
+	}
+
+	const suggestions = findSuggestions(body.url, pages, deadUrlEmbedding);
 
 	// Log asynchronously
 	if (suggestions.length > 0) {

--- a/src/engine/embeddings.ts
+++ b/src/engine/embeddings.ts
@@ -1,0 +1,108 @@
+import type { PageRecord } from "../types.js";
+
+const OPENAI_EMBEDDING_URL = "https://api.openai.com/v1/embeddings";
+const MODEL = "text-embedding-3-small";
+const DIMENSIONS = 256;
+
+/**
+ * Generate an embedding for a single text string.
+ * Returns null if the API key is missing or the request fails.
+ */
+export async function generateEmbedding(text: string): Promise<number[] | null> {
+	const results = await generateBatchEmbeddings([text]);
+	return results[0];
+}
+
+/**
+ * Generate embeddings for multiple texts in a single API call.
+ * Returns null for any text that fails.
+ */
+export async function generateBatchEmbeddings(texts: string[]): Promise<(number[] | null)[]> {
+	const apiKey = process.env.OPENAI_API_KEY;
+	if (!apiKey || texts.length === 0) {
+		return texts.map(() => null);
+	}
+
+	try {
+		const resp = await fetch(OPENAI_EMBEDDING_URL, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				input: texts,
+				model: MODEL,
+				dimensions: DIMENSIONS,
+			}),
+		});
+
+		if (!resp.ok) {
+			console.error(`Embedding API error: ${resp.status} ${resp.statusText}`);
+			return texts.map(() => null);
+		}
+
+		const data = (await resp.json()) as {
+			data: { embedding: number[]; index: number }[];
+		};
+
+		const results: (number[] | null)[] = texts.map(() => null);
+		for (const item of data.data) {
+			results[item.index] = item.embedding;
+		}
+		return results;
+	} catch (err) {
+		console.error("Embedding API request failed:", err);
+		return texts.map(() => null);
+	}
+}
+
+/**
+ * Build the text to embed for a page: URL path segments + title + description.
+ */
+export function buildEmbeddingText(page: Pick<PageRecord, "url" | "title" | "description">): string {
+	let pathPart = "";
+	try {
+		const u = new URL(page.url);
+		pathPart = u.pathname
+			.split("/")
+			.filter(Boolean)
+			.map((s) => s.replace(/[-_]/g, " "))
+			.join(" ");
+	} catch {
+		pathPart = page.url;
+	}
+
+	return [pathPart, page.title, page.description].filter(Boolean).join(" — ");
+}
+
+/**
+ * Generate an embedding for a page record.
+ */
+export async function generatePageEmbedding(
+	page: Pick<PageRecord, "url" | "title" | "description">,
+): Promise<number[] | null> {
+	const text = buildEmbeddingText(page);
+	return generateEmbedding(text);
+}
+
+/**
+ * Generate an embedding for a dead URL (used at suggest time).
+ * Builds text from the URL path segments.
+ */
+export async function generateDeadUrlEmbedding(deadUrl: string): Promise<number[] | null> {
+	let text = "";
+	try {
+		const u = new URL(deadUrl);
+		text = u.pathname
+			.split("/")
+			.filter(Boolean)
+			.map((s) => s.replace(/[-_]/g, " "))
+			.join(" ");
+	} catch {
+		text = deadUrl;
+	}
+
+	if (!text) return null;
+	return generateEmbedding(text);
+}

--- a/src/engine/embeddings.ts
+++ b/src/engine/embeddings.ts
@@ -1,7 +1,7 @@
 import type { PageRecord } from "../types.js";
 
-const OPENAI_EMBEDDING_URL = "https://api.openai.com/v1/embeddings";
-const MODEL = "text-embedding-3-small";
+const EMBEDDING_URL = process.env.EMBEDDING_API_URL || "https://openrouter.ai/api/v1/embeddings";
+const MODEL = process.env.EMBEDDING_MODEL || "openai/text-embedding-3-small";
 const DIMENSIONS = 256;
 
 /**
@@ -18,13 +18,13 @@ export async function generateEmbedding(text: string): Promise<number[] | null> 
  * Returns null for any text that fails.
  */
 export async function generateBatchEmbeddings(texts: string[]): Promise<(number[] | null)[]> {
-	const apiKey = process.env.OPENAI_API_KEY;
+	const apiKey = process.env.EMBEDDING_API_KEY || process.env.OPENAI_API_KEY;
 	if (!apiKey || texts.length === 0) {
 		return texts.map(() => null);
 	}
 
 	try {
-		const resp = await fetch(OPENAI_EMBEDDING_URL, {
+		const resp = await fetch(EMBEDDING_URL, {
 			method: "POST",
 			headers: {
 				Authorization: `Bearer ${apiKey}`,

--- a/src/engine/indexer.ts
+++ b/src/engine/indexer.ts
@@ -1,15 +1,17 @@
 import type { PageRecord } from "../types.js";
 import type { StorageAdapter } from "../storage/interface.js";
+import { generatePageEmbedding } from "./embeddings.js";
 
 /**
- * Upsert a single page record from a beacon.
+ * Upsert a single page record from a beacon, generating an embedding.
  */
 export async function registerPage(
 	storage: StorageAdapter,
 	siteId: string,
 	page: Pick<PageRecord, "url" | "title" | "description" | "headings">,
 ): Promise<void> {
-	await storage.upsertPage(siteId, page);
+	const embedding = await generatePageEmbedding(page);
+	await storage.upsertPage(siteId, page, embedding);
 }
 
 /**

--- a/src/engine/matcher.ts
+++ b/src/engine/matcher.ts
@@ -2,14 +2,27 @@ import type { PageRecord, Suggestion } from "../types.js";
 
 const SCORE_THRESHOLD = 0.2;
 const MAX_RESULTS = 5;
-const WEIGHT_PATH_SEG = 0.5;
-const WEIGHT_LEVENSHTEIN = 0.3;
-const WEIGHT_TEXT = 0.2;
+
+// 4-signal weights (when embedding available)
+const W4_PATH_SEG = 0.35;
+const W4_LEVENSHTEIN = 0.2;
+const W4_TEXT = 0.15;
+const W4_EMBEDDING = 0.3;
+
+// 3-signal weights (fallback when embedding unavailable)
+const W3_PATH_SEG = 0.5;
+const W3_LEVENSHTEIN = 0.3;
+const W3_TEXT = 0.2;
 
 /**
  * Rank pages against a dead URL and return top suggestions.
+ * Optionally accepts a dead URL embedding for semantic matching.
  */
-export function findSuggestions(deadUrl: string, pages: PageRecord[]): Suggestion[] {
+export function findSuggestions(
+	deadUrl: string,
+	pages: PageRecord[],
+	deadUrlEmbedding?: number[] | null,
+): Suggestion[] {
 	const deadPath = normalizePath(deadUrl);
 	const deadSegments = pathSegments(deadPath);
 	const deadKeywords = extractKeywords(deadPath);
@@ -36,10 +49,23 @@ export function findSuggestions(deadUrl: string, pages: PageRecord[]): Suggestio
 		]);
 		const textScore = keywordOverlap(deadKeywords, textKeywords);
 
-		const score =
-			WEIGHT_PATH_SEG * pathSegScore +
-			WEIGHT_LEVENSHTEIN * levScore +
-			WEIGHT_TEXT * textScore;
+		// Signal 4: Embedding cosine similarity (when both embeddings available)
+		const hasEmbedding = deadUrlEmbedding && page.embedding;
+		let score: number;
+
+		if (hasEmbedding) {
+			const embeddingScore = cosineSimilarity(deadUrlEmbedding, page.embedding!);
+			score =
+				W4_PATH_SEG * pathSegScore +
+				W4_LEVENSHTEIN * levScore +
+				W4_TEXT * textScore +
+				W4_EMBEDDING * embeddingScore;
+		} else {
+			score =
+				W3_PATH_SEG * pathSegScore +
+				W3_LEVENSHTEIN * levScore +
+				W3_TEXT * textScore;
+		}
 
 		if (score >= SCORE_THRESHOLD) {
 			const hasVersionDiff = detectVersionDiff(deadSegments, pageSegments);
@@ -63,6 +89,21 @@ export function findSuggestions(deadUrl: string, pages: PageRecord[]): Suggestio
 }
 
 // --- Helpers ---
+
+export function cosineSimilarity(a: number[], b: number[]): number {
+	if (a.length !== b.length || a.length === 0) return 0;
+	let dot = 0;
+	let normA = 0;
+	let normB = 0;
+	for (let i = 0; i < a.length; i++) {
+		dot += a[i] * b[i];
+		normA += a[i] * a[i];
+		normB += b[i] * b[i];
+	}
+	const denom = Math.sqrt(normA) * Math.sqrt(normB);
+	if (denom === 0) return 0;
+	return dot / denom;
+}
 
 function normalizePath(url: string): string {
 	try {

--- a/src/engine/sitemap.ts
+++ b/src/engine/sitemap.ts
@@ -1,8 +1,11 @@
 import type { PageRecord } from "../types.js";
 import type { StorageAdapter } from "../storage/interface.js";
+import { buildEmbeddingText, generateBatchEmbeddings } from "./embeddings.js";
+
+const EMBEDDING_BATCH_SIZE = 100;
 
 /**
- * Crawl a domain's sitemap.xml and upsert all discovered URLs.
+ * Crawl a domain's sitemap.xml and upsert all discovered URLs with embeddings.
  */
 export async function crawlSitemap(domain: string, siteId: string, storage: StorageAdapter): Promise<number> {
 	const sitemapUrl = `https://${domain}/sitemap.xml`;
@@ -20,7 +23,16 @@ export async function crawlSitemap(domain: string, siteId: string, storage: Stor
 		);
 
 		if (pages.length > 0) {
-			await storage.upsertPages(siteId, pages);
+			// Generate embeddings in batches
+			const allEmbeddings: (number[] | null)[] = [];
+			for (let i = 0; i < pages.length; i += EMBEDDING_BATCH_SIZE) {
+				const batch = pages.slice(i, i + EMBEDDING_BATCH_SIZE);
+				const texts = batch.map((p) => buildEmbeddingText(p));
+				const embeddings = await generateBatchEmbeddings(texts);
+				allEmbeddings.push(...embeddings);
+			}
+
+			await storage.upsertPages(siteId, pages, allEmbeddings);
 			count = pages.length;
 		}
 	} catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { suggest } from "./api/routes/suggest.js";
 import { apiKeyAuth } from "./api/middleware/auth.js";
 import { crawlSitemap } from "./engine/sitemap.js";
 import { pruneStalePages } from "./engine/indexer.js";
+import { buildEmbeddingText, generateBatchEmbeddings } from "./engine/embeddings.js";
 import { landingPageHtml } from "./landing.js";
 
 type Env = { Variables: { storage: PostgresStorage; siteId: string } };
@@ -55,7 +56,39 @@ app.get("/api/cron", async (c) => {
 		const domain = row.domain as string;
 		const crawled = await crawlSitemap(domain, siteId, storage);
 		const pruned = await pruneStalePages(storage, siteId, 30);
-		results.push({ domain, crawled, pruned });
+
+		// Backfill embeddings for pages missing them
+		let backfilled = 0;
+		const { rows: nullPages } = await sql`
+			SELECT * FROM pages WHERE site_id = ${siteId} AND embedding IS NULL
+		`;
+		if (nullPages.length > 0) {
+			const BATCH_SIZE = 100;
+			for (let i = 0; i < nullPages.length; i += BATCH_SIZE) {
+				const batch = nullPages.slice(i, i + BATCH_SIZE);
+				const texts = batch.map((p) =>
+					buildEmbeddingText({
+						url: p.url as string,
+						title: p.title as string,
+						description: p.description as string,
+					}),
+				);
+				const embeddings = await generateBatchEmbeddings(texts);
+				for (let j = 0; j < batch.length; j++) {
+					const emb = embeddings[j];
+					if (emb) {
+						const embStr = `[${emb.join(",")}]`;
+						await sql.query(
+							`UPDATE pages SET embedding = $1::vector WHERE id = $2`,
+							[embStr, batch[j].id],
+						);
+						backfilled++;
+					}
+				}
+			}
+		}
+
+		results.push({ domain, crawled, pruned, backfilled });
 	}
 
 	return c.json({ ok: true, results });

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -270,23 +270,6 @@ export const landingPageHtml = `<!DOCTYPE html>
       line-height: 1.4;
     }
 
-    /* Stack */
-    .stack-list {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      margin-top: 1rem;
-    }
-    .stack-tag {
-      font-family: var(--mono);
-      font-size: 0.8rem;
-      padding: 0.35rem 0.75rem;
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--text-secondary);
-    }
-
     /* CTA */
     .cta {
       text-align: center;
@@ -430,8 +413,6 @@ export const landingPageHtml = `<!DOCTYPE html>
       <div class="logo">agent<span>-</span>404</div>
       <div class="links">
         <a href="https://github.com/bharath31/agent-404">GitHub</a>
-        <a href="#get-started">Get started</a>
-        <a href="/api/health">API Status</a>
       </div>
     </nav>
 
@@ -518,28 +499,18 @@ export const landingPageHtml = `<!DOCTYPE html>
       </div>
     </div>
 
-    <div class="section">
-      <h2>Stack</h2>
-      <p style="color: var(--text-secondary); font-size: 0.9rem;">Fully open source. Self-host or use the hosted version.</p>
-      <div class="stack-list">
-        <span class="stack-tag">Hono</span>
-        <span class="stack-tag">Vercel Edge Functions</span>
-        <span class="stack-tag">PostgreSQL</span>
-        <span class="stack-tag">Vanilla JS &lt;3KB</span>
-        <span class="stack-tag">schema.org JSON-LD</span>
-        <span class="stack-tag">MIT License</span>
-      </div>
-    </div>
-
     <div class="cta">
       <h2>Stop losing agents to dead links</h2>
-      <p>Add one script tag. Your 404 pages start working for you.</p>
+      <p>Add one script tag. Your 404 pages start working for you.<br>Fully open source — self-host with one click or use the hosted version.</p>
       <div class="btn-group">
-        <a href="https://github.com/bharath31/agent-404" class="btn btn-primary">
+        <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,OPENAI_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20OPENAI_API_KEY%3A%20For%20semantic%20embeddings%20(optional).%20CRON_SECRET%3A%20Bearer%20token%20for%20cron.&project-name=agent-404&repository-name=agent-404" class="btn btn-primary">
+          <svg width="16" height="16" viewBox="0 0 76 65" fill="currentColor"><path d="M37.5274 0L75.0548 65H0L37.5274 0Z"/></svg>
+          Deploy to Vercel
+        </a>
+        <a href="https://github.com/bharath31/agent-404" class="btn btn-secondary">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
           View on GitHub
         </a>
-        <a href="/api/health" class="btn btn-secondary">API Status</a>
       </div>
     </div>
 

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -503,7 +503,7 @@ export const landingPageHtml = `<!DOCTYPE html>
       <h2>Stop losing agents to dead links</h2>
       <p>Add one script tag. Your 404 pages start working for you.<br>Fully open source — self-host with one click or use the hosted version.</p>
       <div class="btn-group">
-        <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,OPENAI_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20OPENAI_API_KEY%3A%20For%20semantic%20embeddings%20(optional).%20CRON_SECRET%3A%20Bearer%20token%20for%20cron.&project-name=agent-404&repository-name=agent-404" class="btn btn-primary">
+        <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,EMBEDDING_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20EMBEDDING_API_KEY%3A%20For%20semantic%20embeddings%20(optional).%20CRON_SECRET%3A%20Bearer%20token%20for%20cron.&project-name=agent-404&repository-name=agent-404" class="btn btn-primary">
           <svg width="16" height="16" viewBox="0 0 76 65" fill="currentColor"><path d="M37.5274 0L75.0548 65H0L37.5274 0Z"/></svg>
           Deploy to Vercel
         </a>

--- a/src/storage/interface.ts
+++ b/src/storage/interface.ts
@@ -8,12 +8,15 @@ export interface StorageAdapter {
 	upsertPage(
 		siteId: string,
 		page: Pick<PageRecord, "url" | "title" | "description" | "headings">,
+		embedding?: number[] | null,
 	): Promise<void>;
 	upsertPages(
 		siteId: string,
 		pages: Pick<PageRecord, "url" | "title" | "description" | "headings">[],
+		embeddings?: (number[] | null)[],
 	): Promise<void>;
 	getPages(siteId: string): Promise<PageRecord[]>;
+	searchByEmbedding(siteId: string, embedding: number[], limit: number): Promise<PageRecord[]>;
 	deleteStalePagesOlderThan(siteId: string, cutoff: string): Promise<number>;
 
 	recordSuggestionServed(siteId: string, deadUrl: string, suggestedUrls: string[]): Promise<void>;

--- a/src/storage/postgres.ts
+++ b/src/storage/postgres.ts
@@ -29,25 +29,55 @@ export class PostgresStorage implements StorageAdapter {
 	async upsertPage(
 		siteId: string,
 		page: Pick<PageRecord, "url" | "title" | "description" | "headings">,
+		embedding?: number[] | null,
 	): Promise<void> {
-		await sql`
-			INSERT INTO pages (site_id, url, title, description, headings)
-			VALUES (${siteId}, ${page.url}, ${page.title}, ${page.description}, ${page.headings})
-			ON CONFLICT (site_id, url) DO UPDATE SET
-				title = EXCLUDED.title,
-				description = EXCLUDED.description,
-				headings = EXCLUDED.headings,
-				last_seen = NOW()
-		`;
+		if (embedding) {
+			const embeddingStr = `[${embedding.join(",")}]`;
+			await sql.query(
+				`INSERT INTO pages (site_id, url, title, description, headings, embedding)
+				VALUES ($1, $2, $3, $4, $5, $6::vector)
+				ON CONFLICT (site_id, url) DO UPDATE SET
+					title = EXCLUDED.title,
+					description = EXCLUDED.description,
+					headings = EXCLUDED.headings,
+					embedding = COALESCE(EXCLUDED.embedding, pages.embedding),
+					last_seen = NOW()`,
+				[siteId, page.url, page.title, page.description, page.headings, embeddingStr],
+			);
+		} else {
+			await sql`
+				INSERT INTO pages (site_id, url, title, description, headings)
+				VALUES (${siteId}, ${page.url}, ${page.title}, ${page.description}, ${page.headings})
+				ON CONFLICT (site_id, url) DO UPDATE SET
+					title = EXCLUDED.title,
+					description = EXCLUDED.description,
+					headings = EXCLUDED.headings,
+					last_seen = NOW()
+			`;
+		}
 	}
 
 	async upsertPages(
 		siteId: string,
 		pages: Pick<PageRecord, "url" | "title" | "description" | "headings">[],
+		embeddings?: (number[] | null)[],
 	): Promise<void> {
-		for (const page of pages) {
-			await this.upsertPage(siteId, page);
+		for (let i = 0; i < pages.length; i++) {
+			const embedding = embeddings?.[i] ?? null;
+			await this.upsertPage(siteId, pages[i], embedding);
 		}
+	}
+
+	async searchByEmbedding(siteId: string, embedding: number[], limit: number): Promise<PageRecord[]> {
+		const embeddingStr = `[${embedding.join(",")}]`;
+		const { rows } = await sql.query(
+			`SELECT * FROM pages
+			WHERE site_id = $1 AND embedding IS NOT NULL
+			ORDER BY embedding <=> $2::vector
+			LIMIT $3`,
+			[siteId, embeddingStr, limit],
+		);
+		return rows.map(this.mapPageRow);
 	}
 
 	async getPages(siteId: string): Promise<PageRecord[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface PageRecord {
 	description: string;
 	headings: string; // JSON array of strings
 	lastSeen: string;
+	embedding?: number[] | null;
 }
 
 export interface Suggestion {


### PR DESCRIPTION
Embeddings fix the class of misses where URLs share zero lexical similarity but point to the same content (e.g. /docs/authentication → /guides/security/oauth). Uses OpenAI text-embedding-3-small (256d) via raw fetch — no new dependencies.

- Migration adds vector(256) column + HNSW index to pages table
- Embedding client with batch support and graceful fallback
- Vector pre-filter (top 20 by cosine similarity) replaces full-table scan
- 4-signal weights (0.35/0.20/0.15/0.30), falls back to 3-signal when unavailable
- Cron backfills NULL embeddings in batches of 100
- Deploy to Vercel button on landing page and README
- Remove Stack section and nav buttons from landing page