### PR TITLE
README badges, embedding docs, Vercel deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # agent-404
 
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Tests](https://img.shields.io/github/actions/workflow/status/bharath31/agent-404/ci.yml?label=tests)](https://github.com/bharath31/agent-404/actions)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,EMBEDDING_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20EMBEDDING_API_KEY%3A%20For%20semantic%20embeddings%20(optional).%20CRON_SECRET%3A%20Bearer%20token%20for%20cron.&project-name=agent-404&repository-name=agent-404)
+
 Make your 404 pages agent-friendly. When AI agents and crawlers hit a dead link, they give up or hallucinate. **agent-404** returns structured suggestions of the next best pages — so agents recover gracefully.
 
 One script tag. That's it.
@@ -27,15 +31,25 @@ The script detects 404 pages using (in order):
 - `<meta name="agent-404:status" content="404">` — meta tag
 - Page title containing "404" or "not found"
 
-### Fuzzy Matching
+### Ranking — 4 signals
 
-Suggestions are ranked using four signals:
-- **Path segment similarity** — Jaccard similarity on URL segments, version-tolerant (`v2` → `v3` = partial match)
-- **Levenshtein distance** — catches typos and minor path differences
-- **Keyword overlap** — matches words from the dead URL against page titles and headings
-- **Semantic embeddings** — cosine similarity on OpenAI `text-embedding-3-small` vectors, catches URLs with zero lexical overlap but same meaning (e.g. `/docs/authentication` → `/guides/security/oauth`)
+Suggestions are ranked by a weighted combination of four signals:
 
-When embeddings are unavailable (no API key or API down), the system gracefully falls back to the first three signals.
+| Signal | Weight | What it catches |
+|---|---|---|
+| **Path segment similarity** | 0.35 | Jaccard on URL segments, version-tolerant (`v2` → `v3` = partial match) |
+| **Semantic embeddings** | 0.30 | Cosine similarity on 256d vectors — catches zero-lexical-overlap rewrites (e.g. `/docs/authentication` → `/guides/security/oauth`) |
+| **Levenshtein distance** | 0.20 | Typos and minor path differences |
+| **Keyword overlap** | 0.15 | Words from dead URL matched against page titles and headings |
+
+Embeddings are generated via any OpenAI-compatible API (default: OpenRouter with `openai/text-embedding-3-small`). Set `EMBEDDING_API_KEY` to enable; if missing or the API is down, the system falls back to 3-signal matching with the original weights (0.50 / 0.30 / 0.20).
+
+#### How embeddings work
+
+- **On write** — when a page is registered (beacon or sitemap crawl), its URL path + title + description are embedded and stored as a `vector(256)` column in Postgres (pgvector)
+- **On suggest** — the dead URL is embedded and used as a vector pre-filter (`ORDER BY embedding <=> query LIMIT 20`) to pull the top 20 candidates, which are then re-ranked with all 4 signals
+- **Backfill** — the daily cron job generates embeddings for any pages that are missing them (in batches of 100)
+- **Config** — `EMBEDDING_API_URL` and `EMBEDDING_MODEL` env vars let you point at any provider (OpenAI, Azure, local)
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # agent-404
 
+<p align="center">
+  <img src="public/banner.svg" alt="agent-404 — Agent-friendly 404 pages" width="100%">
+</p>
+
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Tests](https://img.shields.io/github/actions/workflow/status/bharath31/agent-404/ci.yml?label=tests)](https://github.com/bharath31/agent-404/actions)
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,EMBEDDING_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20EMBEDDING_API_KEY%3A%20For%20semantic%20embeddings%20(optional).%20CRON_SECRET%3A%20Bearer%20token%20for%20cron.&project-name=agent-404&repository-name=agent-404)

--- a/public/banner.svg
+++ b/public/banner.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" fill="none">
+  <rect width="1200" height="300" rx="16" fill="#0a0a0b"/>
+  <rect x="0.5" y="0.5" width="1199" height="299" rx="15.5" stroke="#27272a"/>
+
+  <!-- Subtle grid pattern -->
+  <defs>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#27272a" stroke-width="0.5" opacity="0.4"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="300" rx="16" fill="url(#grid)"/>
+
+  <!-- Accent glow -->
+  <ellipse cx="600" cy="150" rx="300" ry="120" fill="#3b82f6" opacity="0.04"/>
+
+  <!-- Logo mark -->
+  <rect x="80" y="100" width="88" height="88" rx="18" fill="#3b82f6"/>
+  <text x="124" y="155" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="36" font-weight="800" fill="white" text-anchor="middle" dominant-baseline="middle">404</text>
+
+  <!-- Title -->
+  <text x="196" y="132" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="44" font-weight="700" fill="#fafafa">agent<tspan fill="#52525b">-</tspan>404</text>
+
+  <!-- Tagline -->
+  <text x="196" y="172" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif" font-size="18" fill="#a1a1aa">Agent-friendly 404 pages. One script tag.</text>
+
+  <!-- Pills -->
+  <rect x="710" y="115" width="120" height="30" rx="15" fill="none" stroke="#27272a"/>
+  <text x="770" y="134" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="12" fill="#22c55e" text-anchor="middle">open source</text>
+
+  <rect x="840" y="115" width="80" height="30" rx="15" fill="none" stroke="#27272a"/>
+  <text x="880" y="134" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="12" fill="#a1a1aa" text-anchor="middle">MIT</text>
+
+  <rect x="930" y="115" width="110" height="30" rx="15" fill="none" stroke="#27272a"/>
+  <text x="985" y="134" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="12" fill="#3b82f6" text-anchor="middle">pgvector</text>
+
+  <!-- Bottom detail line -->
+  <line x1="80" y1="230" x2="1120" y2="230" stroke="#27272a" stroke-width="1"/>
+  <text x="80" y="258" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" fill="#52525b">$ curl -X POST /api/suggest -d '{"url": "https://example.com/docs/v2/auth"}'</text>
+  <text x="1120" y="258" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="13" fill="#22c55e" text-anchor="end">→ /docs/v3/auth (0.85)</text>
+</svg>

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -303,6 +303,11 @@ export const landingPageHtml = `<!DOCTYPE html>
       color: white;
     }
     .btn-primary:hover { background: var(--accent-dim); text-decoration: none; }
+    .btn-vercel {
+      background: #fff;
+      color: #000;
+    }
+    .btn-vercel:hover { background: #e5e5e5; text-decoration: none; }
     .btn-secondary {
       background: var(--surface);
       color: var(--text);
@@ -503,7 +508,7 @@ export const landingPageHtml = `<!DOCTYPE html>
       <h2>Stop losing agents to dead links</h2>
       <p>Add one script tag. Your 404 pages start working for you.<br>Fully open source — self-host with one click or use the hosted version.</p>
       <div class="btn-group">
-        <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,EMBEDDING_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20EMBEDDING_API_KEY%3A%20For%20semantic%20embeddings%20(optional).%20CRON_SECRET%3A%20Bearer%20token%20for%20cron.&project-name=agent-404&repository-name=agent-404" class="btn btn-primary">
+        <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fbharath31%2Fagent-404&env=POSTGRES_URL,EMBEDDING_API_KEY,CRON_SECRET&envDescription=POSTGRES_URL%3A%20Neon%2FVercel%20Postgres%20connection%20string.%20EMBEDDING_API_KEY%3A%20For%20semantic%20embeddings%20(optional).%20CRON_SECRET%3A%20Bearer%20token%20for%20cron.&project-name=agent-404&repository-name=agent-404" class="btn btn-vercel">
           <svg width="16" height="16" viewBox="0 0 76 65" fill="currentColor"><path d="M37.5274 0L75.0548 65H0L37.5274 0Z"/></svg>
           Deploy to Vercel
         </a>


### PR DESCRIPTION
## Summary
- Added MIT license, tests, and Deploy with Vercel badges to README header
- Expanded the ranking section into a weight table with full embedding architecture docs (write path, suggest path, backfill, config)
- Styled the landing page deploy button black & white to match Vercel's branding

## Test plan
- [ ] Verify badges render correctly on GitHub
- [ ] Verify landing page deploy button is white with black text
- [ ] Click deploy button and confirm it opens Vercel with correct env var prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)