### PR TITLE
Improve demo sitemap crawling for large sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,3 +63,9 @@ Unit tests (`vitest.config.ts`) exclude `e2e.test.ts` and `browser.test.ts`. E2E
 ## Environment Variables
 
 Configured in `.env.local` (gitignored). Required: `DATABASE_URL`. Optional: `EMBEDDING_API_KEY`, `EMBEDDING_API_URL`, `EMBEDDING_MODEL`, `CRON_SECRET`.
+
+## Roadmap
+
+### Matcher improvements
+- **Substring/prefix matching for path segments** — Currently "work" doesn't match "workers" because Jaccard requires exact token equality. Add partial-match scoring (e.g., if one segment is a prefix of another with min length 3, count as a 0.7 match instead of 0). This would fix cases like `developers.cloudflare.com/work/` → `/workers/`.
+- **Stemming or fuzzy token matching** — "message" doesn't match "messaging" at the token level. A lightweight stemmer or edit-distance-based token similarity (e.g., tokens within Levenshtein distance 2 count as partial matches) would improve recall for typo-like dead URLs.

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -817,7 +817,7 @@ export const demoPageHtml = `<!DOCTYPE html>
           ? result.error
           : 'Could not discover pages on ' + hostname + '. The site may have no sitemap, llms.txt, or discoverable links.';
         document.getElementById('results-list').innerHTML =
-          '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">' + errorMsg + '</div>';
+          '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">' + escapeHtml(errorMsg) + '</div>';
         return;
       }
       const sourceLabel = result.source !== 'none' ? ' via ' + result.source : '';
@@ -857,12 +857,12 @@ export const demoPageHtml = `<!DOCTYPE html>
         card.style.animationDelay = (i * 0.08) + 's';
         card.innerHTML =
           '<div class="result-top">' +
-            '<span class="match-badge ' + r.matchType + '">' + r.matchType + '</span>' +
-            '<a class="result-url" href="' + r.url + '" target="_blank" rel="noopener">' + r.url + '</a>' +
+            '<span class="match-badge ' + escapeHtml(r.matchType) + '">' + escapeHtml(r.matchType) + '</span>' +
+            '<a class="result-url" href="' + escapeHtml(r.url) + '" target="_blank" rel="noopener">' + escapeHtml(r.url) + '</a>' +
             '<span class="result-score">' + r.score + '</span>' +
           '</div>' +
-          '<div class="result-title">' + r.title + '</div>' +
-          '<div class="result-desc">' + r.description + '</div>' +
+          '<div class="result-title">' + escapeHtml(r.title) + '</div>' +
+          '<div class="result-desc">' + escapeHtml(r.description) + '</div>' +
           '<div class="signals">' +
             '<span class="signal">path <span class="signal-bar"><span class="signal-fill path" style="width:' + Math.round(r._signals.path * 100) + '%"></span></span> ' + r._signals.path.toFixed(2) + '</span>' +
             '<span class="signal">lev <span class="signal-bar"><span class="signal-fill lev" style="width:' + Math.round(r._signals.lev * 100) + '%"></span></span> ' + r._signals.lev.toFixed(2) + '</span>' +
@@ -890,6 +890,10 @@ export const demoPageHtml = `<!DOCTYPE html>
         }
       };
       document.getElementById('jsonld-pre').innerHTML = syntaxHighlight(JSON.stringify(jsonld, null, 2));
+    }
+
+    function escapeHtml(s) {
+      return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     }
 
     function syntaxHighlight(json) {

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -798,7 +798,7 @@ export const demoPageHtml = `<!DOCTYPE html>
       if (knownPages) {
         // Check if known pages produce good matches; if not, try live discovery
         const knownResults = findSuggestions(deadUrl, knownPages);
-        if (knownResults.length > 0 && knownResults[0].score > 0.35) {
+        if (knownResults.length > 0 && knownResults[0].score > 0.40) {
           showResults(deadUrl, context, knownPages);
           return;
         }

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -691,6 +691,10 @@ export const demoPageHtml = `<!DOCTYPE html>
       if (!ma || !mb) return false;
       return ma[1] === mb[1] && ma[2] !== mb[2];
     }
+    function isPrefixMatch(a, b) {
+      if (a.length < 3 || b.length < 3) return false;
+      return a.startsWith(b) || b.startsWith(a);
+    }
     function jaccardVersionTolerant(a, b) {
       if (!a.length && !b.length) return 1;
       if (!a.length || !b.length) return 0;
@@ -701,6 +705,10 @@ export const demoPageHtml = `<!DOCTYPE html>
         else {
           const vm = b.find(bs => !used.has(bs) && isVersionVariant(seg, bs));
           if (vm) { matches += 0.5; used.add(vm); }
+          else {
+            const pm = b.find(bs => !used.has(bs) && isPrefixMatch(seg, bs));
+            if (pm) { matches += 0.7; used.add(pm); }
+          }
         }
       }
       return matches / new Set([...a, ...b]).size;
@@ -720,7 +728,12 @@ export const demoPageHtml = `<!DOCTYPE html>
     function keywordOverlap(a, b) {
       if (!a.size || !b.size) return 0;
       let inter = 0;
-      for (const w of a) if (b.has(w)) inter++;
+      for (const w of a) {
+        if (b.has(w)) { inter++; }
+        else {
+          for (const bw of b) { if (isPrefixMatch(w, bw)) { inter += 0.7; break; } }
+        }
+      }
       return inter / new Set([...a, ...b]).size;
     }
     function findSuggestions(deadUrl, pages) {
@@ -783,8 +796,13 @@ export const demoPageHtml = `<!DOCTYPE html>
     async function runWithPages(deadUrl, context) {
       const knownPages = getKnownSitePages(deadUrl);
       if (knownPages) {
-        showResults(deadUrl, context, knownPages);
-        return;
+        // Check if known pages produce good matches; if not, try live discovery
+        const knownResults = findSuggestions(deadUrl, knownPages);
+        if (knownResults.length > 0 && knownResults[0].score > 0.35) {
+          showResults(deadUrl, context, knownPages);
+          return;
+        }
+        // Known pages didn't match well — fall through to live discovery
       }
 
       // Unknown domain — fetch sitemap

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -795,26 +795,26 @@ export const demoPageHtml = `<!DOCTYPE html>
       const deadDisplay = document.getElementById('dead-url-display');
       deadDisplay.href = deadUrl;
       deadDisplay.textContent = deadUrl;
-      document.getElementById('dead-url-context').textContent = 'Fetching sitemap for ' + hostname + '...';
+      document.getElementById('dead-url-context').textContent = 'Discovering pages on ' + hostname + '...';
       document.getElementById('empty-state').style.display = 'none';
       const container = document.getElementById('results-container');
       container.style.display = 'block';
       document.getElementById('results-count').textContent = 'loading...';
       document.getElementById('results-list').innerHTML =
-        '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">Crawling ' + hostname + '/sitemap.xml for pages...</div>';
+        '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">Checking sitemap, robots.txt, and page links on ' + hostname + '...</div>';
       document.getElementById('jsonld-section').style.display = 'none';
 
       let deadPath = '';
       try { deadPath = new URL(deadUrl).pathname; } catch {}
       const pages = await fetchSitemapPages(hostname, deadPath);
       if (pages.length === 0) {
-        document.getElementById('dead-url-context').textContent = 'No sitemap found';
+        document.getElementById('dead-url-context').textContent = 'No pages discovered';
         document.getElementById('results-count').textContent = '0 matches';
         document.getElementById('results-list').innerHTML =
-          '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">Could not find a sitemap.xml for ' + hostname + '. The site needs a sitemap for the demo to discover its pages.</div>';
+          '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">Could not discover pages on ' + hostname + '. The site may block bots or have no discoverable links.</div>';
         return;
       }
-      document.getElementById('dead-url-context').textContent = pages.length + ' pages indexed from sitemap';
+      document.getElementById('dead-url-context').textContent = pages.length + ' pages discovered';
       showResults(deadUrl, '', pages);
     }
 

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -655,7 +655,7 @@ export const demoPageHtml = `<!DOCTYPE html>
         const resp = await fetch(url);
         const data = await resp.json();
         const pages = (data.pages || []).map(p => ({
-          url: p.url, title: p.title || '', description: '', headings: '[]'
+          url: p.url, title: p.title || '', description: p.description || '', headings: '[]'
         }));
         sitemapCache[cacheKey] = { pages, ts: Date.now() };
         return pages;

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -801,7 +801,7 @@ export const demoPageHtml = `<!DOCTYPE html>
       container.style.display = 'block';
       document.getElementById('results-count').textContent = 'loading...';
       document.getElementById('results-list').innerHTML =
-        '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">Checking sitemap, robots.txt, and page links on ' + hostname + '...</div>';
+        '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">Checking llms.txt, sitemap, robots.txt, and page links on ' + hostname + '...</div>';
       document.getElementById('jsonld-section').style.display = 'none';
 
       let deadPath = '';

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -643,25 +643,24 @@ export const demoPageHtml = `<!DOCTYPE html>
       return null;
     }
 
-    function getCachedSitemapPages(domain) {
-      const entry = sitemapCache[domain];
-      if (entry && (Date.now() - entry.ts) < 5 * 60 * 1000) return entry.pages;
-      return null;
-    }
 
-    async function fetchSitemapPages(domain) {
-      const cached = getCachedSitemapPages(domain);
-      if (cached !== null) return cached;
+    async function fetchSitemapPages(domain, deadPath) {
+      // Cache key includes path so different paths can prioritize different sitemaps
+      const cacheKey = domain + ':' + (deadPath || '');
+      const entry = sitemapCache[cacheKey];
+      if (entry && (Date.now() - entry.ts) < 5 * 60 * 1000) return entry.pages;
       try {
-        const resp = await fetch('/api/demo/sitemap?domain=' + encodeURIComponent(domain));
+        let url = '/api/demo/sitemap?domain=' + encodeURIComponent(domain);
+        if (deadPath) url += '&path=' + encodeURIComponent(deadPath);
+        const resp = await fetch(url);
         const data = await resp.json();
         const pages = (data.pages || []).map(p => ({
           url: p.url, title: p.title || '', description: '', headings: '[]'
         }));
-        sitemapCache[domain] = { pages, ts: Date.now() };
+        sitemapCache[cacheKey] = { pages, ts: Date.now() };
         return pages;
       } catch {
-        sitemapCache[domain] = { pages: [], ts: Date.now() };
+        sitemapCache[cacheKey] = { pages: [], ts: Date.now() };
         return [];
       }
     }
@@ -805,7 +804,9 @@ export const demoPageHtml = `<!DOCTYPE html>
         '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">Crawling ' + hostname + '/sitemap.xml for pages...</div>';
       document.getElementById('jsonld-section').style.display = 'none';
 
-      const pages = await fetchSitemapPages(hostname);
+      let deadPath = '';
+      try { deadPath = new URL(deadUrl).pathname; } catch {}
+      const pages = await fetchSitemapPages(hostname, deadPath);
       if (pages.length === 0) {
         document.getElementById('dead-url-context').textContent = 'No sitemap found';
         document.getElementById('results-count').textContent = '0 matches';

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -648,7 +648,7 @@ export const demoPageHtml = `<!DOCTYPE html>
       // Cache key includes path so different paths can prioritize different sitemaps
       const cacheKey = domain + ':' + (deadPath || '');
       const entry = sitemapCache[cacheKey];
-      if (entry && (Date.now() - entry.ts) < 5 * 60 * 1000) return entry.pages;
+      if (entry && (Date.now() - entry.ts) < 5 * 60 * 1000) return entry;
       try {
         let url = '/api/demo/sitemap?domain=' + encodeURIComponent(domain);
         if (deadPath) url += '&path=' + encodeURIComponent(deadPath);
@@ -657,11 +657,13 @@ export const demoPageHtml = `<!DOCTYPE html>
         const pages = (data.pages || []).map(p => ({
           url: p.url, title: p.title || '', description: p.description || '', headings: '[]'
         }));
-        sitemapCache[cacheKey] = { pages, ts: Date.now() };
-        return pages;
+        const result = { pages, source: data.source || 'none', error: data.error || null, ts: Date.now() };
+        sitemapCache[cacheKey] = result;
+        return result;
       } catch {
-        sitemapCache[cacheKey] = { pages: [], ts: Date.now() };
-        return [];
+        const result = { pages: [], source: 'none', error: null, ts: Date.now() };
+        sitemapCache[cacheKey] = result;
+        return result;
       }
     }
 
@@ -806,16 +808,21 @@ export const demoPageHtml = `<!DOCTYPE html>
 
       let deadPath = '';
       try { deadPath = new URL(deadUrl).pathname; } catch {}
-      const pages = await fetchSitemapPages(hostname, deadPath);
-      if (pages.length === 0) {
-        document.getElementById('dead-url-context').textContent = 'No pages discovered';
+      const result = await fetchSitemapPages(hostname, deadPath);
+      if (result.pages.length === 0) {
+        const sourceLabel = result.source !== 'none' ? ' via ' + result.source : '';
+        document.getElementById('dead-url-context').textContent = 'No pages discovered' + sourceLabel;
         document.getElementById('results-count').textContent = '0 matches';
+        const errorMsg = result.error
+          ? result.error
+          : 'Could not discover pages on ' + hostname + '. The site may have no sitemap, llms.txt, or discoverable links.';
         document.getElementById('results-list').innerHTML =
-          '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">Could not discover pages on ' + hostname + '. The site may block bots or have no discoverable links.</div>';
+          '<div style="text-align:center;padding:2rem;color:#52525b;font-size:0.85rem;">' + errorMsg + '</div>';
         return;
       }
-      document.getElementById('dead-url-context').textContent = pages.length + ' pages discovered';
-      showResults(deadUrl, '', pages);
+      const sourceLabel = result.source !== 'none' ? ' via ' + result.source : '';
+      document.getElementById('dead-url-context').textContent = result.pages.length + ' pages discovered' + sourceLabel;
+      showResults(deadUrl, '', result.pages);
     }
 
     function showResults(deadUrl, context, pages) {

--- a/src/engine/matcher.ts
+++ b/src/engine/matcher.ts
@@ -136,7 +136,13 @@ function safeParseArray(json: string): string[] {
 	}
 }
 
-/** Jaccard similarity with version-tolerance: v2 vs v3 = 0.5 match */
+/** Check if one string is a prefix of the other (min 3 chars) */
+function isPrefixMatch(a: string, b: string): boolean {
+	if (a.length < 3 || b.length < 3) return false;
+	return a.startsWith(b) || b.startsWith(a);
+}
+
+/** Jaccard similarity with version-tolerance and prefix matching */
 function jaccardVersionTolerant(a: string[], b: string[]): number {
 	if (a.length === 0 && b.length === 0) return 1;
 	if (a.length === 0 || b.length === 0) return 0;
@@ -157,6 +163,15 @@ function jaccardVersionTolerant(a: string[], b: string[]): number {
 			if (versionMatch) {
 				matches += 0.5;
 				used.add(versionMatch);
+			} else {
+				// Prefix match: "work" ↔ "workers" = 0.7
+				const prefixMatch = b.find(
+					(bSeg) => !used.has(bSeg) && isPrefixMatch(seg, bSeg),
+				);
+				if (prefixMatch) {
+					matches += 0.7;
+					used.add(prefixMatch);
+				}
 			}
 		}
 	}
@@ -212,7 +227,17 @@ function keywordOverlap(a: Set<string>, b: Set<string>): number {
 	if (a.size === 0 || b.size === 0) return 0;
 	let intersection = 0;
 	for (const word of a) {
-		if (b.has(word)) intersection++;
+		if (b.has(word)) {
+			intersection++;
+		} else {
+			// Prefix match: "message" matches "messaging" as 0.7
+			for (const bWord of b) {
+				if (isPrefixMatch(word, bWord)) {
+					intersection += 0.7;
+					break;
+				}
+			}
+		}
 	}
 	const union = new Set([...a, ...b]).size;
 	return intersection / union;

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,14 +211,19 @@ async function fetchDemoResponse(url: string): Promise<FetchMeta> {
  * Check if discovered pages are relevant to the dead URL's section.
  * Returns false if the dead URL has a clear path prefix (e.g., /docs/)
  * but none of the discovered pages share that prefix.
+ * Uses prefix matching so "/work/" matches "/workers/".
  */
 function hasRelevantPages(pages: DemoPage[], deadPath: string): boolean {
 	const deadSegments = deadPath.split("/").filter(Boolean);
 	if (deadSegments.length === 0) return pages.length > 0;
-	const deadPrefix = "/" + deadSegments[0] + "/";
+	const firstSeg = deadSegments[0].toLowerCase();
+	if (firstSeg.length < 3) return pages.length > 0;
 	return pages.some((p) => {
 		try {
-			return new URL(p.url).pathname.startsWith(deadPrefix);
+			const pageSegs = new URL(p.url).pathname.split("/").filter(Boolean);
+			return pageSegs.some(
+				(seg) => seg.toLowerCase().startsWith(firstSeg) || firstSeg.startsWith(seg.toLowerCase()),
+			);
 		} catch {
 			return false;
 		}
@@ -444,9 +449,41 @@ async function followChildLlmsTxt(
 	const deadSegments = deadPath.toLowerCase().split("/").filter(Boolean);
 	const scored = children.map((child) => {
 		let score = 0;
-		const childLower = child.url.toLowerCase() + " " + child.title.toLowerCase();
+		// Extract path segments from the child URL for matching
+		let childPathSegs: string[] = [];
+		try {
+			childPathSegs = new URL(child.url).pathname.toLowerCase().split("/").filter(Boolean);
+			// Remove trailing "llms.txt" from path segments
+			if (childPathSegs.length > 0 && childPathSegs[childPathSegs.length - 1] === "llms.txt") {
+				childPathSegs.pop();
+			}
+		} catch {}
+		const childTitle = child.title.toLowerCase();
+
 		for (const seg of deadSegments) {
-			if (seg.length > 2 && childLower.includes(seg)) score += 2;
+			if (seg.length < 3) continue;
+			// Prefix match on URL path segments (work → workers)
+			// Prefer closer matches: "workers" over "workers-ai" for "work"
+			let bestPathScore = 0;
+			for (const cSeg of childPathSegs) {
+				if (cSeg === seg) {
+					bestPathScore = 5; // exact match
+					break;
+				}
+				if (cSeg.startsWith(seg) || seg.startsWith(cSeg)) {
+					// Closer length = higher score (3-4 range)
+					const lenRatio = Math.min(seg.length, cSeg.length) / Math.max(seg.length, cSeg.length);
+					bestPathScore = Math.max(bestPathScore, 3 + lenRatio);
+				}
+			}
+			score += bestPathScore;
+			// Prefix match on title words
+			for (const word of childTitle.split(/\W+/)) {
+				if (word.length >= 3 && (word.startsWith(seg) || seg.startsWith(word))) {
+					score += 2;
+					break;
+				}
+			}
 		}
 		return { ...child, score };
 	});
@@ -626,11 +663,22 @@ function scoreChildSitemap(childUrl: string, deadPath: string): number {
 	if (GENERIC_SITEMAP_RE.test(childLower)) score += 1;
 	if (deadSegments.length === 0) return score;
 
+	// Extract path segments from the child sitemap URL for prefix matching
+	let childPathSegs: string[] = [];
+	try {
+		childPathSegs = new URL(childUrl).pathname.toLowerCase().split("/").filter(Boolean);
+	} catch {}
+
 	for (const seg of deadSegments) {
-		if (seg.length > 2 && childLower.includes(seg)) score += 2;
+		if (seg.length < 3) continue;
+		// Prefix match on path segments (avoids "work" matching "network")
+		for (const cSeg of childPathSegs) {
+			if (cSeg.startsWith(seg) || seg.startsWith(cSeg)) {
+				score += 3;
+				break;
+			}
+		}
 	}
-	const deadPrefix = "/" + deadSegments[0] + "/";
-	if (childLower.includes(deadPrefix)) score += 3;
 
 	return score;
 }
@@ -684,8 +732,12 @@ async function fetchDemoSitemap(
 	if (!xml) return [];
 
 	if (!xml.includes("<sitemapindex")) {
-		return extractDemoLocs(xml, "url")
-			.slice(0, DEMO_MAX_URLS)
+		const allLocs = extractDemoLocs(xml, "url");
+		if (allLocs.length <= DEMO_MAX_URLS) {
+			return allLocs.map((loc) => ({ url: loc, title: demoTitleFromUrl(loc) }));
+		}
+		// More URLs than our cap — prioritize URLs relevant to the dead path
+		return prioritizeLocs(allLocs, deadPath)
 			.map((loc) => ({ url: loc, title: demoTitleFromUrl(loc) }));
 	}
 
@@ -856,6 +908,26 @@ function extractInternalLinks(
 }
 
 // ── Shared utilities ──
+
+/**
+ * When a sitemap has more URLs than DEMO_MAX_URLS, prioritize URLs
+ * that share path segments with the dead URL's path.
+ */
+function prioritizeLocs(locs: string[], deadPath: string): string[] {
+	const deadSegments = deadPath.toLowerCase().split("/").filter((s) => s.length > 2);
+	if (deadSegments.length === 0) return locs.slice(0, DEMO_MAX_URLS);
+
+	const scored = locs.map((loc) => {
+		const locLower = loc.toLowerCase();
+		let score = 0;
+		for (const seg of deadSegments) {
+			if (locLower.includes(seg)) score += 1;
+		}
+		return { loc, score };
+	});
+	scored.sort((a, b) => b.score - a.score);
+	return scored.slice(0, DEMO_MAX_URLS).map((s) => s.loc);
+}
 
 function extractDemoLocs(xml: string, parentTag: string): string[] {
 	const urls: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,11 +60,13 @@ app.use("/api/suggest", rateLimiter({ windowMs: 60_000, max: 60 }));
 app.get("/", (c) => c.html(landingPageHtml));
 app.get("/demo", (c) => c.html(demoPageHtml));
 
-// Demo sitemap proxy — fetches & parses a domain's sitemap.xml for the live demo
+// Demo sitemap proxy — fetches & parses a domain's sitemap.xml for the live demo.
+// Accepts the dead URL to prioritize the most relevant child sitemaps.
 // No auth needed, but rate-limited. Returns lightweight page list (URL + title).
 app.use("/api/demo/sitemap", rateLimiter({ windowMs: 60_000, max: 15 }));
 app.get("/api/demo/sitemap", async (c) => {
 	const domain = c.req.query("domain");
+	const deadPath = c.req.query("path") || "";
 	if (!domain || typeof domain !== "string" || domain.length > 253) {
 		return c.json({ error: "domain query parameter is required" }, 400);
 	}
@@ -89,52 +91,98 @@ app.get("/api/demo/sitemap", async (c) => {
 	}
 
 	const sitemapUrl = `https://${domain}/sitemap.xml`;
-	const TIMEOUT_MS = 8_000;
-	const MAX_URLS = 500;
 
 	try {
-		const pages = await fetchDemoSitemap(sitemapUrl, TIMEOUT_MS, MAX_URLS);
+		const pages = await fetchDemoSitemap(sitemapUrl, deadPath, 0);
 		return c.json({ domain, pages });
 	} catch {
 		return c.json({ domain, pages: [], error: "Could not fetch sitemap" });
 	}
 });
 
-async function fetchDemoSitemap(
-	url: string,
-	timeoutMs: number,
-	maxUrls: number,
-): Promise<{ url: string; title: string }[]> {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+const DEMO_TIMEOUT_MS = 8_000;
+const DEMO_MAX_URLS = 500;
+const DEMO_MAX_DEPTH = 2;
+const DEMO_MAX_CHILDREN = 5;
 
+async function fetchDemoSitemapXml(url: string): Promise<string | null> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), DEMO_TIMEOUT_MS);
 	try {
 		const resp = await fetch(url, {
 			headers: { "User-Agent": "agent-404-bot/1.0 (demo)" },
 			signal: controller.signal,
 		});
-		if (!resp.ok) return [];
-
-		const xml = await resp.text();
-
-		// Handle sitemap index — fetch first 3 child sitemaps
-		if (xml.includes("<sitemapindex")) {
-			const childLocs = extractDemoLocs(xml, "sitemap").slice(0, 3);
-			const allPages: { url: string; title: string }[] = [];
-			for (const childUrl of childLocs) {
-				if (allPages.length >= maxUrls) break;
-				const childPages = await fetchDemoSitemap(childUrl, timeoutMs, maxUrls - allPages.length);
-				allPages.push(...childPages);
-			}
-			return allPages.slice(0, maxUrls);
-		}
-
-		return extractDemoLocs(xml, "url")
-			.slice(0, maxUrls)
-			.map((loc) => ({ url: loc, title: titleFromUrl(loc) }));
+		if (!resp.ok) return null;
+		const contentType = resp.headers.get("content-type") || "";
+		// Reject HTML responses (some sites return 200 with an HTML 404 page)
+		if (contentType.includes("text/html")) return null;
+		return await resp.text();
+	} catch {
+		return null;
 	} finally {
 		clearTimeout(timeout);
 	}
+}
+
+/**
+ * Score a child sitemap URL by how relevant it is to the dead URL path.
+ * Higher = more relevant.
+ */
+function scoreChildSitemap(childUrl: string, deadPath: string): number {
+	const childLower = childUrl.toLowerCase();
+	const deadLower = deadPath.toLowerCase();
+	const deadSegments = deadLower.split("/").filter(Boolean);
+	if (deadSegments.length === 0) return 0;
+
+	let score = 0;
+	// Bonus for each dead URL segment that appears in the child sitemap URL
+	for (const seg of deadSegments) {
+		if (seg.length > 2 && childLower.includes(seg)) score += 2;
+	}
+	// Bonus for path prefix match (e.g., dead=/docs/start, child URL contains /docs/)
+	const deadPrefix = "/" + deadSegments[0] + "/";
+	if (childLower.includes(deadPrefix)) score += 3;
+
+	return score;
+}
+
+async function fetchDemoSitemap(
+	url: string,
+	deadPath: string,
+	depth: number,
+): Promise<{ url: string; title: string }[]> {
+	const xml = await fetchDemoSitemapXml(url);
+	if (!xml) return [];
+
+	// Not a sitemap index — extract URLs directly
+	if (!xml.includes("<sitemapindex")) {
+		return extractDemoLocs(xml, "url")
+			.slice(0, DEMO_MAX_URLS)
+			.map((loc) => ({ url: loc, title: demoTitleFromUrl(loc) }));
+	}
+
+	// Sitemap index — prioritize children by relevance to the dead URL
+	if (depth >= DEMO_MAX_DEPTH) return [];
+	const childLocs = extractDemoLocs(xml, "sitemap");
+	if (childLocs.length === 0) return [];
+
+	// Score and sort children by relevance, falling back to original order
+	const scored = childLocs.map((loc, i) => ({
+		loc,
+		score: scoreChildSitemap(loc, deadPath),
+		idx: i,
+	}));
+	scored.sort((a, b) => b.score - a.score || a.idx - b.idx);
+	const topChildren = scored.slice(0, DEMO_MAX_CHILDREN);
+
+	// Fetch top children in parallel
+	const results = await Promise.all(
+		topChildren.map((child) => fetchDemoSitemap(child.loc, deadPath, depth + 1)),
+	);
+
+	const allPages = results.flat();
+	return allPages.slice(0, DEMO_MAX_URLS);
 }
 
 function extractDemoLocs(xml: string, parentTag: string): string[] {
@@ -151,7 +199,7 @@ function extractDemoLocs(xml: string, parentTag: string): string[] {
 	return urls;
 }
 
-function titleFromUrl(url: string): string {
+function demoTitleFromUrl(url: string): string {
 	try {
 		const path = new URL(url).pathname;
 		const last = path.split("/").filter(Boolean).pop() || "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,8 +101,8 @@ app.get("/api/demo/sitemap", async (c) => {
 // ── Demo page discovery constants ──
 const DEMO_TIMEOUT_MS = 8_000;
 const DEMO_MAX_URLS = 500;
-const DEMO_MAX_DEPTH = 2;
-const DEMO_MAX_CHILDREN = 5;
+const DEMO_MAX_DEPTH = 3;
+const DEMO_MAX_CHILDREN = 8;
 const DEMO_USER_AGENT = "agent-404-bot/1.0 (demo)";
 
 // Common sitemap paths to try (in order)
@@ -115,29 +115,149 @@ const SITEMAP_PATHS = [
 ];
 
 /**
- * Main discovery pipeline: sitemap → robots.txt → HTML crawl fallback.
+ * Main discovery pipeline: llms.txt → sitemap → HTML crawl fallback.
  */
 async function discoverDemoPages(
 	domain: string,
 	deadPath: string,
-): Promise<{ url: string; title: string }[]> {
-	// 1. Try sitemaps (from robots.txt + common paths)
-	const sitemapUrls = await findSitemapUrls(domain);
+): Promise<{ url: string; title: string; description?: string }[]> {
+	// 1. Try llms.txt — curated page list with real titles and descriptions
+	const llmsPages = await fetchLlmsTxt(domain, deadPath);
+	if (llmsPages.length > 0) return llmsPages;
+
+	// 2. Try sitemaps (from robots.txt + common paths + path-prefix sitemaps)
+	const sitemapUrls = await findSitemapUrls(domain, deadPath);
 	for (const sitemapUrl of sitemapUrls) {
 		const pages = await fetchDemoSitemap(sitemapUrl, deadPath, 0);
 		if (pages.length > 0) return pages;
 	}
 
-	// 2. Fallback: crawl HTML links from the homepage and nearby pages
+	// 3. Fallback: crawl HTML links from the homepage and nearby pages
 	return await crawlDemoLinks(domain, deadPath);
 }
 
 /**
- * Find sitemap URLs by checking robots.txt, then falling back to common paths.
+ * Fetch and parse llms.txt — a structured file listing a site's key pages.
+ * Handles nested llms.txt (like Cloudflare) by following child llms.txt links
+ * that are relevant to the dead URL path.
  */
-async function findSitemapUrls(domain: string): Promise<string[]> {
+async function fetchLlmsTxt(
+	domain: string,
+	deadPath: string,
+): Promise<{ url: string; title: string; description: string }[]> {
+	const text = await fetchDemoText(`https://${domain}/llms.txt`);
+	if (!text || text.length < 20) return [];
+
+	const { pages, childLlmsTxtUrls } = parseLlmsTxt(text, domain);
+
+	// If we got real pages, return them
+	if (pages.length > 0) return pages;
+
+	// If no pages but found child llms.txt links (e.g., Cloudflare), follow relevant ones
+	if (childLlmsTxtUrls.length > 0) {
+		return await followChildLlmsTxt(childLlmsTxtUrls, domain, deadPath);
+	}
+
+	return [];
+}
+
+/**
+ * Parse llms.txt content into pages and child llms.txt URLs.
+ */
+function parseLlmsTxt(
+	text: string,
+	domain: string,
+): {
+	pages: { url: string; title: string; description: string }[];
+	childLlmsTxtUrls: { url: string; title: string }[];
+} {
+	const pages: { url: string; title: string; description: string }[] = [];
+	const childLlmsTxtUrls: { url: string; title: string }[] = [];
+	const seen = new Set<string>();
+
+	// Match markdown links: [Title](URL): Description  or  [Title](URL)
+	const linkRegex = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)(?:\s*:\s*(.+))?/g;
+	let match: RegExpExecArray | null;
+	while ((match = linkRegex.exec(text)) !== null) {
+		const title = match[1].trim();
+		let url = match[2].trim();
+		const description = match[3]?.trim() || "";
+
+		// Only keep same-domain links
+		try {
+			const parsed = new URL(url);
+			if (parsed.hostname !== domain && !parsed.hostname.endsWith("." + domain)) continue;
+		} catch {
+			continue;
+		}
+
+		// Separate child llms.txt links from actual pages
+		if (url.endsWith("/llms.txt")) {
+			if (!seen.has(url)) {
+				seen.add(url);
+				childLlmsTxtUrls.push({ url, title });
+			}
+			continue;
+		}
+
+		// Normalize .md and /index.md extensions
+		url = url.replace(/\/index\.md$/, "/").replace(/\.md$/, "");
+
+		if (seen.has(url) || pages.length >= DEMO_MAX_URLS) continue;
+		seen.add(url);
+		pages.push({ url, title, description });
+	}
+
+	return { pages, childLlmsTxtUrls };
+}
+
+/**
+ * Follow child llms.txt links, prioritizing ones relevant to the dead URL.
+ */
+async function followChildLlmsTxt(
+	children: { url: string; title: string }[],
+	domain: string,
+	deadPath: string,
+): Promise<{ url: string; title: string; description: string }[]> {
+	// Score children by relevance to the dead URL path
+	const deadSegments = deadPath.toLowerCase().split("/").filter(Boolean);
+	const scored = children.map((child) => {
+		let score = 0;
+		const childLower = child.url.toLowerCase() + " " + child.title.toLowerCase();
+		for (const seg of deadSegments) {
+			if (seg.length > 2 && childLower.includes(seg)) score += 2;
+		}
+		return { ...child, score };
+	});
+	scored.sort((a, b) => b.score - a.score);
+
+	// Fetch top 3 most relevant child llms.txt files in parallel
+	const topChildren = scored.slice(0, 3);
+	const results = await Promise.all(
+		topChildren.map(async (child) => {
+			const text = await fetchDemoText(child.url);
+			if (!text) return [];
+			const { pages } = parseLlmsTxt(text, domain);
+			return pages;
+		}),
+	);
+
+	return results.flat().slice(0, DEMO_MAX_URLS);
+}
+
+/**
+ * Find sitemap URLs by checking robots.txt, path-prefix sitemaps, and common paths.
+ */
+async function findSitemapUrls(domain: string, deadPath: string): Promise<string[]> {
 	const found: string[] = [];
 	const seen = new Set<string>();
+
+	const addUrl = (url: string) => {
+		if (url.startsWith("https://") && !seen.has(url)) {
+			seen.add(url);
+			found.push(url);
+		}
+	};
 
 	// Check robots.txt for Sitemap directives
 	const robotsTxt = await fetchDemoText(`https://${domain}/robots.txt`);
@@ -145,21 +265,22 @@ async function findSitemapUrls(domain: string): Promise<string[]> {
 		const sitemapRegex = /^Sitemap:\s*(\S+)/gim;
 		let match: RegExpExecArray | null;
 		while ((match = sitemapRegex.exec(robotsTxt)) !== null) {
-			const url = match[1].trim();
-			if (url.startsWith("https://") && !seen.has(url)) {
-				seen.add(url);
-				found.push(url);
-			}
+			addUrl(match[1].trim());
 		}
 	}
 
-	// Add common paths not already discovered
+	// Try path-prefix sitemaps based on the dead URL
+	// e.g., dead path /docs/messaging → try /docs/sitemap.xml
+	const deadSegments = deadPath.split("/").filter(Boolean);
+	for (let i = 1; i <= Math.min(deadSegments.length, 2); i++) {
+		const prefix = "/" + deadSegments.slice(0, i).join("/");
+		addUrl(`https://${domain}${prefix}/sitemap.xml`);
+		addUrl(`https://${domain}${prefix}/sitemap-0.xml`);
+	}
+
+	// Add common root paths not already discovered
 	for (const path of SITEMAP_PATHS) {
-		const url = `https://${domain}${path}`;
-		if (!seen.has(url)) {
-			seen.add(url);
-			found.push(url);
-		}
+		addUrl(`https://${domain}${path}`);
 	}
 
 	return found;
@@ -187,7 +308,7 @@ async function fetchDemoText(url: string): Promise<string | null> {
 }
 
 /**
- * Fetch a URL expecting XML. Rejects HTML responses.
+ * Fetch a URL expecting XML. Rejects HTML and empty responses.
  */
 async function fetchDemoSitemapXml(url: string): Promise<string | null> {
 	const controller = new AbortController();
@@ -202,8 +323,11 @@ async function fetchDemoSitemapXml(url: string): Promise<string | null> {
 		const contentType = resp.headers.get("content-type") || "";
 		if (contentType.includes("text/html")) return null;
 		const text = await resp.text();
-		// Double-check: some servers return HTML with XML content-type
-		if (text.trimStart().startsWith("<!DOCTYPE") || text.trimStart().startsWith("<html")) return null;
+		// Reject empty responses (some sites return 200 with no body)
+		if (!text || text.trim().length === 0) return null;
+		// Reject HTML disguised with XML content-type
+		const trimmed = text.trimStart();
+		if (trimmed.startsWith("<!DOCTYPE") || trimmed.startsWith("<html")) return null;
 		return text;
 	} catch {
 		return null;
@@ -212,20 +336,32 @@ async function fetchDemoSitemapXml(url: string): Promise<string | null> {
 	}
 }
 
+/** Check if a sitemap child URL has a generic name (sitemap-0.xml, etc.) */
+const GENERIC_SITEMAP_RE = /\/sitemap[-_]?\d*\.xml$/i;
+
 /**
  * Score a child sitemap URL by relevance to the dead URL path.
+ * Generic names (sitemap-0.xml) get a baseline score so they aren't ignored.
  */
 function scoreChildSitemap(childUrl: string, deadPath: string): number {
 	const childLower = childUrl.toLowerCase();
 	const deadSegments = deadPath.toLowerCase().split("/").filter(Boolean);
-	if (deadSegments.length === 0) return 0;
 
 	let score = 0;
+
+	// Generic sitemap names get a baseline — they often contain the "main" pages
+	if (GENERIC_SITEMAP_RE.test(childLower)) score += 1;
+
+	if (deadSegments.length === 0) return score;
+
+	// Bonus for each dead URL segment that appears in the child sitemap URL
 	for (const seg of deadSegments) {
 		if (seg.length > 2 && childLower.includes(seg)) score += 2;
 	}
+	// Bonus for path prefix match (e.g., dead=/docs/start → child contains /docs/)
 	const deadPrefix = "/" + deadSegments[0] + "/";
 	if (childLower.includes(deadPrefix)) score += 3;
+
 	return score;
 }
 
@@ -252,13 +388,16 @@ async function fetchDemoSitemap(
 	const childLocs = extractDemoLocs(xml, "sitemap");
 	if (childLocs.length === 0) return [];
 
+	// For small indexes, fetch all children; for large ones, pick the best
+	const limit = childLocs.length <= 10 ? childLocs.length : DEMO_MAX_CHILDREN;
+
 	const scored = childLocs.map((loc, i) => ({
 		loc,
 		score: scoreChildSitemap(loc, deadPath),
 		idx: i,
 	}));
 	scored.sort((a, b) => b.score - a.score || a.idx - b.idx);
-	const topChildren = scored.slice(0, DEMO_MAX_CHILDREN);
+	const topChildren = scored.slice(0, limit);
 
 	const results = await Promise.all(
 		topChildren.map((child) => fetchDemoSitemap(child.loc, deadPath, depth + 1)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,11 +99,14 @@ app.get("/api/demo/sitemap", async (c) => {
 });
 
 // ── Demo page discovery constants ──
-const DEMO_TIMEOUT_MS = 8_000;
+const DEMO_FETCH_TIMEOUT_MS = 8_000;
+const DEMO_PIPELINE_TIMEOUT_MS = 20_000;
 const DEMO_MAX_URLS = 500;
+const DEMO_MAX_BODY_BYTES = 2 * 1024 * 1024; // 2 MB cap per response
 const DEMO_MAX_DEPTH = 3;
 const DEMO_MAX_CHILDREN = 8;
-const DEMO_USER_AGENT = "agent-404-bot/1.0 (demo)";
+const DEMO_USER_AGENT =
+	"Mozilla/5.0 (compatible; agent-404-bot/1.0; +https://agent-404.vercel.app)";
 
 // Common sitemap paths to try (in order)
 const SITEMAP_PATHS = [
@@ -114,48 +117,81 @@ const SITEMAP_PATHS = [
 	"/wp-sitemap.xml",
 ];
 
+type DemoPage = { url: string; title: string; description?: string };
+
 /**
- * Main discovery pipeline: llms.txt → sitemap → HTML crawl fallback.
+ * Main discovery pipeline with overall timeout.
+ * Order: llms.txt → sitemap → HTML crawl fallback.
+ * All steps race against a pipeline-level deadline so the user never waits forever.
  */
 async function discoverDemoPages(
 	domain: string,
 	deadPath: string,
-): Promise<{ url: string; title: string; description?: string }[]> {
-	// 1. Try llms.txt — curated page list with real titles and descriptions
-	const llmsPages = await fetchLlmsTxt(domain, deadPath);
-	if (llmsPages.length > 0) return llmsPages;
+): Promise<DemoPage[]> {
+	const deadline = Date.now() + DEMO_PIPELINE_TIMEOUT_MS;
 
-	// 2. Try sitemaps (from robots.txt + common paths + path-prefix sitemaps)
-	const sitemapUrls = await findSitemapUrls(domain, deadPath);
-	for (const sitemapUrl of sitemapUrls) {
-		const pages = await fetchDemoSitemap(sitemapUrl, deadPath, 0);
-		if (pages.length > 0) return pages;
+	// 1. Try llms.txt — curated page list with real titles and descriptions
+	if (Date.now() < deadline) {
+		const llmsPages = await fetchLlmsTxt(domain, deadPath);
+		if (llmsPages.length > 0) return llmsPages;
 	}
 
-	// 3. Fallback: crawl HTML links from the homepage and nearby pages
-	return await crawlDemoLinks(domain, deadPath);
+	// 2. Try sitemaps (robots.txt + path-prefix + common paths)
+	if (Date.now() < deadline) {
+		const sitemapUrls = await findSitemapUrls(domain, deadPath);
+		for (const sitemapUrl of sitemapUrls) {
+			if (Date.now() >= deadline) break;
+			const pages = await fetchDemoSitemap(sitemapUrl, deadPath, 0);
+			if (pages.length > 0) return pages;
+		}
+	}
+
+	// 3. Fallback: crawl HTML links
+	if (Date.now() < deadline) {
+		return await crawlDemoLinks(domain, deadPath);
+	}
+
+	return [];
 }
+
+// ── llms.txt discovery ──
 
 /**
  * Fetch and parse llms.txt — a structured file listing a site's key pages.
- * Handles nested llms.txt (like Cloudflare) by following child llms.txt links
- * that are relevant to the dead URL path.
+ * Handles nested llms.txt (like Cloudflare) by following child llms.txt links.
+ * Falls back to llms-full.txt if llms.txt yields nothing.
  */
 async function fetchLlmsTxt(
 	domain: string,
 	deadPath: string,
-): Promise<{ url: string; title: string; description: string }[]> {
+): Promise<DemoPage[]> {
+	// Try llms.txt first
 	const text = await fetchDemoText(`https://${domain}/llms.txt`);
-	if (!text || text.length < 20) return [];
+	if (text && text.length >= 20) {
+		const { pages, childLlmsTxtUrls } = parseLlmsTxt(text, domain);
+		if (pages.length > 0) return pages;
+		if (childLlmsTxtUrls.length > 0) {
+			const childPages = await followChildLlmsTxt(childLlmsTxtUrls, domain, deadPath);
+			if (childPages.length > 0) return childPages;
+		}
+	}
 
-	const { pages, childLlmsTxtUrls } = parseLlmsTxt(text, domain);
+	// Try path-prefix llms.txt (e.g., /docs/llms.txt for dead URL /docs/foo)
+	const deadSegments = deadPath.split("/").filter(Boolean);
+	for (let i = 1; i <= Math.min(deadSegments.length, 2); i++) {
+		const prefix = "/" + deadSegments.slice(0, i).join("/");
+		const prefixText = await fetchDemoText(`https://${domain}${prefix}/llms.txt`);
+		if (prefixText && prefixText.length >= 20) {
+			const { pages } = parseLlmsTxt(prefixText, domain);
+			if (pages.length > 0) return pages;
+		}
+	}
 
-	// If we got real pages, return them
-	if (pages.length > 0) return pages;
-
-	// If no pages but found child llms.txt links (e.g., Cloudflare), follow relevant ones
-	if (childLlmsTxtUrls.length > 0) {
-		return await followChildLlmsTxt(childLlmsTxtUrls, domain, deadPath);
+	// Fallback: llms-full.txt (some sites only have this)
+	const fullText = await fetchDemoText(`https://${domain}/llms-full.txt`);
+	if (fullText && fullText.length >= 20) {
+		const { pages } = parseLlmsTxt(fullText, domain);
+		if (pages.length > 0) return pages;
 	}
 
 	return [];
@@ -168,10 +204,10 @@ function parseLlmsTxt(
 	text: string,
 	domain: string,
 ): {
-	pages: { url: string; title: string; description: string }[];
+	pages: DemoPage[];
 	childLlmsTxtUrls: { url: string; title: string }[];
 } {
-	const pages: { url: string; title: string; description: string }[] = [];
+	const pages: DemoPage[] = [];
 	const childLlmsTxtUrls: { url: string; title: string }[] = [];
 	const seen = new Set<string>();
 
@@ -191,8 +227,8 @@ function parseLlmsTxt(
 			continue;
 		}
 
-		// Separate child llms.txt links from actual pages
-		if (url.endsWith("/llms.txt")) {
+		// Separate child llms.txt / llms-full.txt links from actual pages
+		if (url.endsWith("/llms.txt") || url.endsWith("/llms-full.txt")) {
 			if (!seen.has(url)) {
 				seen.add(url);
 				childLlmsTxtUrls.push({ url, title });
@@ -218,8 +254,7 @@ async function followChildLlmsTxt(
 	children: { url: string; title: string }[],
 	domain: string,
 	deadPath: string,
-): Promise<{ url: string; title: string; description: string }[]> {
-	// Score children by relevance to the dead URL path
+): Promise<DemoPage[]> {
 	const deadSegments = deadPath.toLowerCase().split("/").filter(Boolean);
 	const scored = children.map((child) => {
 		let score = 0;
@@ -244,6 +279,8 @@ async function followChildLlmsTxt(
 
 	return results.flat().slice(0, DEMO_MAX_URLS);
 }
+
+// ── Sitemap discovery ──
 
 /**
  * Find sitemap URLs by checking robots.txt, path-prefix sitemaps, and common paths.
@@ -270,7 +307,6 @@ async function findSitemapUrls(domain: string, deadPath: string): Promise<string
 	}
 
 	// Try path-prefix sitemaps based on the dead URL
-	// e.g., dead path /docs/messaging → try /docs/sitemap.xml
 	const deadSegments = deadPath.split("/").filter(Boolean);
 	for (let i = 1; i <= Math.min(deadSegments.length, 2); i++) {
 		const prefix = "/" + deadSegments.slice(0, i).join("/");
@@ -286,20 +322,32 @@ async function findSitemapUrls(domain: string, deadPath: string): Promise<string
 	return found;
 }
 
+// ── HTTP fetch helpers ──
+
 /**
  * Fetch a URL and return text, or null on failure.
+ * Caps response body at DEMO_MAX_BODY_BYTES to prevent OOM on huge files.
  */
 async function fetchDemoText(url: string): Promise<string | null> {
 	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), DEMO_TIMEOUT_MS);
+	const timeout = setTimeout(() => controller.abort(), DEMO_FETCH_TIMEOUT_MS);
 	try {
 		const resp = await fetch(url, {
-			headers: { "User-Agent": DEMO_USER_AGENT },
+			headers: {
+				"User-Agent": DEMO_USER_AGENT,
+				Accept: "text/plain, application/xml, text/xml, text/html, */*",
+			},
 			signal: controller.signal,
 			redirect: "follow",
 		});
 		if (!resp.ok) return null;
-		return await resp.text();
+
+		// Check content-length before reading body
+		const contentLength = parseInt(resp.headers.get("content-length") || "0", 10);
+		if (contentLength > DEMO_MAX_BODY_BYTES) return null;
+
+		// Stream-read with size cap for responses without content-length
+		return await readBodyCapped(resp, DEMO_MAX_BODY_BYTES);
 	} catch {
 		return null;
 	} finally {
@@ -308,22 +356,61 @@ async function fetchDemoText(url: string): Promise<string | null> {
 }
 
 /**
- * Fetch a URL expecting XML. Rejects HTML and empty responses.
+ * Read response body up to maxBytes. Returns null if body exceeds limit.
+ */
+async function readBodyCapped(resp: Response, maxBytes: number): Promise<string | null> {
+	// If body is a ReadableStream, read in chunks with a cap
+	if (resp.body && typeof resp.body.getReader === "function") {
+		const reader = resp.body.getReader();
+		const chunks: Uint8Array[] = [];
+		let totalSize = 0;
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				totalSize += value.byteLength;
+				if (totalSize > maxBytes) {
+					reader.cancel();
+					return null;
+				}
+				chunks.push(value);
+			}
+		} catch {
+			return null;
+		}
+		const decoder = new TextDecoder();
+		return chunks.map((c) => decoder.decode(c, { stream: true })).join("") +
+			decoder.decode();
+	}
+	// Fallback for environments without streaming
+	const text = await resp.text();
+	return text.length > maxBytes ? null : text;
+}
+
+/**
+ * Fetch a URL expecting XML. Rejects HTML, empty, and oversized responses.
  */
 async function fetchDemoSitemapXml(url: string): Promise<string | null> {
 	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), DEMO_TIMEOUT_MS);
+	const timeout = setTimeout(() => controller.abort(), DEMO_FETCH_TIMEOUT_MS);
 	try {
 		const resp = await fetch(url, {
-			headers: { "User-Agent": DEMO_USER_AGENT },
+			headers: {
+				"User-Agent": DEMO_USER_AGENT,
+				Accept: "application/xml, text/xml, */*;q=0.1",
+			},
 			signal: controller.signal,
 			redirect: "follow",
 		});
 		if (!resp.ok) return null;
 		const contentType = resp.headers.get("content-type") || "";
 		if (contentType.includes("text/html")) return null;
-		const text = await resp.text();
-		// Reject empty responses (some sites return 200 with no body)
+
+		// Check content-length before reading
+		const contentLength = parseInt(resp.headers.get("content-length") || "0", 10);
+		if (contentLength > DEMO_MAX_BODY_BYTES) return null;
+
+		const text = await readBodyCapped(resp, DEMO_MAX_BODY_BYTES);
 		if (!text || text.trim().length === 0) return null;
 		// Reject HTML disguised with XML content-type
 		const trimmed = text.trimStart();
@@ -336,29 +423,25 @@ async function fetchDemoSitemapXml(url: string): Promise<string | null> {
 	}
 }
 
+// ── Sitemap parsing ──
+
 /** Check if a sitemap child URL has a generic name (sitemap-0.xml, etc.) */
 const GENERIC_SITEMAP_RE = /\/sitemap[-_]?\d*\.xml$/i;
 
 /**
  * Score a child sitemap URL by relevance to the dead URL path.
- * Generic names (sitemap-0.xml) get a baseline score so they aren't ignored.
  */
 function scoreChildSitemap(childUrl: string, deadPath: string): number {
 	const childLower = childUrl.toLowerCase();
 	const deadSegments = deadPath.toLowerCase().split("/").filter(Boolean);
 
 	let score = 0;
-
-	// Generic sitemap names get a baseline — they often contain the "main" pages
 	if (GENERIC_SITEMAP_RE.test(childLower)) score += 1;
-
 	if (deadSegments.length === 0) return score;
 
-	// Bonus for each dead URL segment that appears in the child sitemap URL
 	for (const seg of deadSegments) {
 		if (seg.length > 2 && childLower.includes(seg)) score += 2;
 	}
-	// Bonus for path prefix match (e.g., dead=/docs/start → child contains /docs/)
 	const deadPrefix = "/" + deadSegments[0] + "/";
 	if (childLower.includes(deadPrefix)) score += 3;
 
@@ -372,25 +455,21 @@ async function fetchDemoSitemap(
 	url: string,
 	deadPath: string,
 	depth: number,
-): Promise<{ url: string; title: string }[]> {
+): Promise<DemoPage[]> {
 	const xml = await fetchDemoSitemapXml(url);
 	if (!xml) return [];
 
-	// Regular sitemap — extract URLs directly
 	if (!xml.includes("<sitemapindex")) {
 		return extractDemoLocs(xml, "url")
 			.slice(0, DEMO_MAX_URLS)
 			.map((loc) => ({ url: loc, title: demoTitleFromUrl(loc) }));
 	}
 
-	// Sitemap index — prioritize children by relevance
 	if (depth >= DEMO_MAX_DEPTH) return [];
 	const childLocs = extractDemoLocs(xml, "sitemap");
 	if (childLocs.length === 0) return [];
 
-	// For small indexes, fetch all children; for large ones, pick the best
 	const limit = childLocs.length <= 10 ? childLocs.length : DEMO_MAX_CHILDREN;
-
 	const scored = childLocs.map((loc, i) => ({
 		loc,
 		score: scoreChildSitemap(loc, deadPath),
@@ -405,21 +484,23 @@ async function fetchDemoSitemap(
 	return results.flat().slice(0, DEMO_MAX_URLS);
 }
 
+// ── HTML crawl fallback ──
+
 /**
- * HTML crawl fallback: fetch homepage + a few relevant pages, extract internal links.
+ * Crawl homepage + ancestor path pages, extract internal links.
+ * Also follows one level of discovered links for broader coverage.
  */
 async function crawlDemoLinks(
 	domain: string,
 	deadPath: string,
-): Promise<{ url: string; title: string }[]> {
+): Promise<DemoPage[]> {
 	const baseUrl = `https://${domain}`;
 	const seen = new Set<string>();
-	const pages: { url: string; title: string }[] = [];
+	const pages: DemoPage[] = [];
 
-	// Seed pages to crawl: homepage + path prefix pages
+	// Seed pages: homepage + ancestor paths
 	const seedPaths = ["/"];
 	const deadSegments = deadPath.split("/").filter(Boolean);
-	// Add ancestor paths (e.g., /docs/guides/start → try /docs, /docs/guides)
 	for (let i = 1; i <= Math.min(deadSegments.length, 3); i++) {
 		seedPaths.push("/" + deadSegments.slice(0, i).join("/"));
 	}
@@ -429,7 +510,6 @@ async function crawlDemoLinks(
 		const html = await fetchDemoText(baseUrl + seedPath);
 		if (!html) continue;
 
-		// Extract page title
 		const seedTitle = extractHtmlTitle(html);
 		const seedUrl = baseUrl + seedPath;
 		if (!seen.has(seedUrl)) {
@@ -437,7 +517,27 @@ async function crawlDemoLinks(
 			pages.push({ url: seedUrl, title: seedTitle });
 		}
 
-		// Extract all internal links
+		const links = extractInternalLinks(html, domain);
+		for (const link of links) {
+			if (seen.has(link.url) || pages.length >= DEMO_MAX_URLS) continue;
+			seen.add(link.url);
+			pages.push(link);
+		}
+	}
+
+	// Second pass: follow top linked pages for more coverage (max 3 extra fetches)
+	const extraSeeds = pages
+		.filter((p) => {
+			// Prefer links that share path segments with the dead URL
+			const pPath = new URL(p.url).pathname.toLowerCase();
+			return deadSegments.some((s) => s.length > 2 && pPath.includes(s));
+		})
+		.slice(0, 3);
+
+	for (const seed of extraSeeds) {
+		if (pages.length >= DEMO_MAX_URLS) break;
+		const html = await fetchDemoText(seed.url);
+		if (!html) continue;
 		const links = extractInternalLinks(html, domain);
 		for (const link of links) {
 			if (seen.has(link.url) || pages.length >= DEMO_MAX_URLS) continue;
@@ -463,29 +563,28 @@ function extractHtmlTitle(html: string): string {
 function extractInternalLinks(
 	html: string,
 	domain: string,
-): { url: string; title: string }[] {
-	const links: { url: string; title: string }[] = [];
+): DemoPage[] {
+	const links: DemoPage[] = [];
 	const seen = new Set<string>();
-	// Match <a> tags, capture href and inner text
 	const regex = /<a\s[^>]*href=["']([^"'#]+)["'][^>]*>([^<]*(?:<[^/a][^>]*>[^<]*)*)<\/a>/gi;
 	let match: RegExpExecArray | null;
 	while ((match = regex.exec(html)) !== null) {
 		let href = match[1].trim();
 		const text = match[2].replace(/<[^>]+>/g, "").trim();
 
-		// Resolve relative URLs
 		if (href.startsWith("/")) {
 			href = `https://${domain}${href}`;
 		}
 
-		// Only keep same-domain HTTPS links
 		try {
 			const parsed = new URL(href);
 			if (parsed.hostname !== domain && !parsed.hostname.endsWith("." + domain)) continue;
 			if (parsed.protocol !== "https:") continue;
-			// Skip anchors, query-only, assets, and common non-page paths
 			const path = parsed.pathname;
-			if (/\.(css|js|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|pdf|zip)$/i.test(path)) continue;
+			if (/\.(css|js|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|pdf|zip|tar|gz)$/i.test(path))
+				continue;
+			// Skip common non-page paths
+			if (/^\/(api|cdn-cgi|_next|_nuxt|__)\//i.test(path)) continue;
 			const canonical = parsed.origin + path.replace(/\/+$/, "");
 			if (seen.has(canonical)) continue;
 			seen.add(canonical);
@@ -496,6 +595,8 @@ function extractInternalLinks(
 	}
 	return links;
 }
+
+// ── Shared utilities ──
 
 function extractDemoLocs(xml: string, parentTag: string): string[] {
 	const urls: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,10 +91,15 @@ app.get("/api/demo/sitemap", async (c) => {
 	}
 
 	try {
-		const pages = await discoverDemoPages(domain, deadPath);
-		return c.json({ domain, pages, source: pages.length > 0 ? "sitemap" : "none" });
+		const result = await discoverDemoPages(domain, deadPath);
+		return c.json({
+			domain,
+			pages: result.pages,
+			source: result.source,
+			...(result.error ? { error: result.error } : {}),
+		});
 	} catch {
-		return c.json({ domain, pages: [], error: "Could not discover pages" });
+		return c.json({ domain, pages: [], source: "none", error: "Could not discover pages" });
 	}
 });
 
@@ -115,9 +120,110 @@ const SITEMAP_PATHS = [
 	"/sitemap/sitemap.xml",
 	"/sitemap/index.xml",
 	"/wp-sitemap.xml",
+	"/sitemap.txt",
 ];
 
 type DemoPage = { url: string; title: string; description?: string };
+
+type DiscoveryResult = {
+	pages: DemoPage[];
+	source: "llms.txt" | "sitemap" | "crawl" | "none";
+	error?: string;
+};
+
+type FetchMeta = {
+	text: string | null;
+	status: number;
+	finalUrl: string;
+};
+
+/**
+ * Detect if a response indicates bot blocking.
+ */
+function detectBlockedResponse(status: number, body: string | null): string | null {
+	if (status === 401) return "This site requires authentication and cannot be crawled publicly.";
+	if (status === 429) return "This site is rate-limiting our requests. Try again later.";
+	if (status === 403) {
+		// Check for specific WAF markers in body
+		if (body) {
+			const lower = body.toLowerCase();
+			if (
+				lower.includes("cf-browser-verification") ||
+				lower.includes("__cf_chl_") ||
+				lower.includes("challenge-platform")
+			) {
+				return "This site is behind Cloudflare bot protection and requires browser verification.";
+			}
+			if (lower.includes("akamai") || lower.includes("ak_bmsc")) {
+				return "This site is behind Akamai bot protection and blocks automated access.";
+			}
+		}
+		return "This site returned 403 Forbidden — it likely blocks automated access.";
+	}
+	if (body) {
+		const lower = body.toLowerCase();
+		if (
+			(lower.includes("access denied") || lower.includes("captcha")) &&
+			lower.includes("<html") &&
+			body.length < 10_000
+		) {
+			return "This site appears to block automated access (access denied / captcha detected).";
+		}
+	}
+	return null;
+}
+
+/**
+ * Fetch a URL and return text + metadata (status, final URL after redirects).
+ */
+async function fetchDemoResponse(url: string): Promise<FetchMeta> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), DEMO_FETCH_TIMEOUT_MS);
+	try {
+		const resp = await fetch(url, {
+			headers: {
+				"User-Agent": DEMO_USER_AGENT,
+				Accept: "text/plain, application/xml, text/xml, text/html, */*",
+			},
+			signal: controller.signal,
+			redirect: "follow",
+		});
+		const finalUrl = resp.url || url;
+		if (!resp.ok) {
+			// Read a small portion of the body for bot-detection purposes
+			const partialBody = await readBodyCapped(resp, 50_000);
+			return { text: partialBody, status: resp.status, finalUrl };
+		}
+		const contentLength = parseInt(resp.headers.get("content-length") || "0", 10);
+		if (contentLength > DEMO_MAX_BODY_BYTES) {
+			return { text: null, status: resp.status, finalUrl };
+		}
+		const text = await readBodyCapped(resp, DEMO_MAX_BODY_BYTES);
+		return { text, status: resp.status, finalUrl };
+	} catch {
+		return { text: null, status: 0, finalUrl: url };
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+/**
+ * Check if discovered pages are relevant to the dead URL's section.
+ * Returns false if the dead URL has a clear path prefix (e.g., /docs/)
+ * but none of the discovered pages share that prefix.
+ */
+function hasRelevantPages(pages: DemoPage[], deadPath: string): boolean {
+	const deadSegments = deadPath.split("/").filter(Boolean);
+	if (deadSegments.length === 0) return pages.length > 0;
+	const deadPrefix = "/" + deadSegments[0] + "/";
+	return pages.some((p) => {
+		try {
+			return new URL(p.url).pathname.startsWith(deadPrefix);
+		} catch {
+			return false;
+		}
+	});
+}
 
 /**
  * Main discovery pipeline with overall timeout.
@@ -127,52 +233,130 @@ type DemoPage = { url: string; title: string; description?: string };
 async function discoverDemoPages(
 	domain: string,
 	deadPath: string,
-): Promise<DemoPage[]> {
+): Promise<DiscoveryResult> {
 	const deadline = Date.now() + DEMO_PIPELINE_TIMEOUT_MS;
+	let effectiveDomain = domain;
+	let blockedReason: string | null = null;
+	let llmsFallbackPages: DemoPage[] | null = null;
 
 	// 1. Try llms.txt — curated page list with real titles and descriptions
 	if (Date.now() < deadline) {
-		const llmsPages = await fetchLlmsTxt(domain, deadPath);
-		if (llmsPages.length > 0) return llmsPages;
+		const llmsResult = await fetchLlmsTxt(effectiveDomain, deadPath);
+		if (llmsResult.pages.length > 0) {
+			if (hasRelevantPages(llmsResult.pages, deadPath)) {
+				return { pages: llmsResult.pages, source: "llms.txt" };
+			}
+			// Pages found but not relevant to the dead URL's section — save as fallback
+			// and continue to sitemap/crawl for better results
+			llmsFallbackPages = llmsResult.pages;
+		}
+		if (llmsResult.redirectDomain) effectiveDomain = llmsResult.redirectDomain;
+		if (llmsResult.blocked) blockedReason = llmsResult.blocked;
 	}
 
 	// 2. Try sitemaps (robots.txt + path-prefix + common paths)
 	if (Date.now() < deadline) {
-		const sitemapUrls = await findSitemapUrls(domain, deadPath);
+		const sitemapUrls = await findSitemapUrls(effectiveDomain, deadPath);
 		for (const sitemapUrl of sitemapUrls) {
 			if (Date.now() >= deadline) break;
-			const pages = await fetchDemoSitemap(sitemapUrl, deadPath, 0);
-			if (pages.length > 0) return pages;
+			const pages = await fetchDemoSitemap(sitemapUrl, deadPath, 0, effectiveDomain);
+			if (pages.length > 0) return { pages, source: "sitemap" };
 		}
 	}
 
 	// 3. Fallback: crawl HTML links
 	if (Date.now() < deadline) {
-		return await crawlDemoLinks(domain, deadPath);
+		const crawlResult = await crawlDemoLinks(effectiveDomain, deadPath);
+		if (crawlResult.pages.length > 0) {
+			return { pages: crawlResult.pages, source: "crawl" };
+		}
+		if (crawlResult.spaDetected) {
+			return {
+				pages: [],
+				source: "none",
+				error:
+					"This site appears to be a single-page application (SPA) that renders content with JavaScript. We can only discover pages from server-rendered HTML, sitemaps, or llms.txt.",
+			};
+		}
+		if (crawlResult.blocked) blockedReason = crawlResult.blocked;
 	}
 
-	return [];
+	// All methods failed — use llms.txt fallback if we had one
+	if (llmsFallbackPages && llmsFallbackPages.length > 0) {
+		return { pages: llmsFallbackPages, source: "llms.txt" };
+	}
+
+	// Return with best error
+	if (blockedReason) {
+		return { pages: [], source: "none", error: blockedReason };
+	}
+	return {
+		pages: [],
+		source: "none",
+		error: `Could not discover pages on ${domain}. The site may have no sitemap, llms.txt, or discoverable links.`,
+	};
 }
 
 // ── llms.txt discovery ──
 
+type LlmsTxtResult = {
+	pages: DemoPage[];
+	redirectDomain?: string;
+	blocked?: string;
+};
+
 /**
  * Fetch and parse llms.txt — a structured file listing a site's key pages.
  * Handles nested llms.txt (like Cloudflare) by following child llms.txt links.
+ * When llms.txt has both real pages and child links, merges both.
  * Falls back to llms-full.txt if llms.txt yields nothing.
  */
 async function fetchLlmsTxt(
 	domain: string,
 	deadPath: string,
-): Promise<DemoPage[]> {
+): Promise<LlmsTxtResult> {
+	let redirectDomain: string | undefined;
+	let blocked: string | undefined;
+
 	// Try llms.txt first
-	const text = await fetchDemoText(`https://${domain}/llms.txt`);
-	if (text && text.length >= 20) {
-		const { pages, childLlmsTxtUrls } = parseLlmsTxt(text, domain);
-		if (pages.length > 0) return pages;
+	const resp = await fetchDemoResponse(`https://${domain}/llms.txt`);
+
+	// Check for cross-domain redirect
+	if (resp.finalUrl) {
+		try {
+			const finalHost = new URL(resp.finalUrl).hostname;
+			if (finalHost !== domain) redirectDomain = finalHost;
+		} catch {}
+	}
+
+	// Check for bot blocking
+	if (!resp.text && resp.status > 0) {
+		const blockMsg = detectBlockedResponse(resp.status, resp.text);
+		if (blockMsg) blocked = blockMsg;
+	}
+
+	const effectiveDomain = redirectDomain || domain;
+
+	if (resp.text && resp.text.length >= 20) {
+		const { pages, childLlmsTxtUrls } = parseLlmsTxt(resp.text, effectiveDomain);
+
+		// Mixed llms.txt: merge direct pages with child pages
+		if (pages.length > 0 && childLlmsTxtUrls.length > 0) {
+			const childPages = await followChildLlmsTxt(childLlmsTxtUrls, effectiveDomain, deadPath);
+			const seen = new Set(pages.map((p) => p.url));
+			for (const cp of childPages) {
+				if (!seen.has(cp.url) && pages.length < DEMO_MAX_URLS) {
+					seen.add(cp.url);
+					pages.push(cp);
+				}
+			}
+			return { pages, redirectDomain };
+		}
+
+		if (pages.length > 0) return { pages, redirectDomain };
 		if (childLlmsTxtUrls.length > 0) {
-			const childPages = await followChildLlmsTxt(childLlmsTxtUrls, domain, deadPath);
-			if (childPages.length > 0) return childPages;
+			const childPages = await followChildLlmsTxt(childLlmsTxtUrls, effectiveDomain, deadPath);
+			if (childPages.length > 0) return { pages: childPages, redirectDomain };
 		}
 	}
 
@@ -180,21 +364,21 @@ async function fetchLlmsTxt(
 	const deadSegments = deadPath.split("/").filter(Boolean);
 	for (let i = 1; i <= Math.min(deadSegments.length, 2); i++) {
 		const prefix = "/" + deadSegments.slice(0, i).join("/");
-		const prefixText = await fetchDemoText(`https://${domain}${prefix}/llms.txt`);
+		const prefixText = await fetchDemoText(`https://${effectiveDomain}${prefix}/llms.txt`);
 		if (prefixText && prefixText.length >= 20) {
-			const { pages } = parseLlmsTxt(prefixText, domain);
-			if (pages.length > 0) return pages;
+			const { pages } = parseLlmsTxt(prefixText, effectiveDomain);
+			if (pages.length > 0) return { pages, redirectDomain };
 		}
 	}
 
 	// Fallback: llms-full.txt (some sites only have this)
-	const fullText = await fetchDemoText(`https://${domain}/llms-full.txt`);
+	const fullText = await fetchDemoText(`https://${effectiveDomain}/llms-full.txt`);
 	if (fullText && fullText.length >= 20) {
-		const { pages } = parseLlmsTxt(fullText, domain);
-		if (pages.length > 0) return pages;
+		const { pages } = parseLlmsTxt(fullText, effectiveDomain);
+		if (pages.length > 0) return { pages, redirectDomain };
 	}
 
-	return [];
+	return { pages: [], redirectDomain, blocked };
 }
 
 /**
@@ -312,6 +496,7 @@ async function findSitemapUrls(domain: string, deadPath: string): Promise<string
 		const prefix = "/" + deadSegments.slice(0, i).join("/");
 		addUrl(`https://${domain}${prefix}/sitemap.xml`);
 		addUrl(`https://${domain}${prefix}/sitemap-0.xml`);
+		addUrl(`https://${domain}${prefix}/sitemap.txt`);
 	}
 
 	// Add common root paths not already discovered
@@ -449,15 +634,52 @@ function scoreChildSitemap(childUrl: string, deadPath: string): number {
 }
 
 /**
+ * Parse a plain-text sitemap (one URL per line).
+ */
+function parsePlainTextSitemap(text: string, filterDomain?: string): DemoPage[] {
+	const pages: DemoPage[] = [];
+	const seen = new Set<string>();
+	for (const line of text.split("\n")) {
+		const url = line.trim();
+		if (!url || !url.startsWith("https://")) continue;
+		if (seen.has(url) || pages.length >= DEMO_MAX_URLS) continue;
+		// Optionally filter to same domain
+		if (filterDomain) {
+			try {
+				const h = new URL(url).hostname;
+				if (h !== filterDomain && !h.endsWith("." + filterDomain)) continue;
+			} catch {
+				continue;
+			}
+		}
+		seen.add(url);
+		pages.push({ url, title: demoTitleFromUrl(url) });
+	}
+	return pages;
+}
+
+/**
  * Recursively fetch and parse sitemaps, prioritizing relevant children.
+ * Supports XML sitemaps and plain-text sitemaps (one URL per line).
  */
 async function fetchDemoSitemap(
 	url: string,
 	deadPath: string,
 	depth: number,
+	filterDomain?: string,
 ): Promise<DemoPage[]> {
 	const xml = await fetchDemoSitemapXml(url);
-	if (!xml) return [];
+	if (!xml) {
+		// Try as plain-text sitemap (one URL per line, e.g. sitemap.txt)
+		if (url.endsWith(".txt") || url.endsWith("/sitemap.txt")) {
+			const text = await fetchDemoText(url);
+			if (text) {
+				const pages = parsePlainTextSitemap(text, filterDomain);
+				if (pages.length > 0) return pages;
+			}
+		}
+		return [];
+	}
 
 	if (!xml.includes("<sitemapindex")) {
 		return extractDemoLocs(xml, "url")
@@ -479,24 +701,48 @@ async function fetchDemoSitemap(
 	const topChildren = scored.slice(0, limit);
 
 	const results = await Promise.all(
-		topChildren.map((child) => fetchDemoSitemap(child.loc, deadPath, depth + 1)),
+		topChildren.map((child) => fetchDemoSitemap(child.loc, deadPath, depth + 1, filterDomain)),
 	);
 	return results.flat().slice(0, DEMO_MAX_URLS);
 }
 
 // ── HTML crawl fallback ──
 
+type CrawlResult = {
+	pages: DemoPage[];
+	spaDetected: boolean;
+	blocked?: string;
+};
+
+/** SPA framework indicators in HTML source */
+const SPA_MARKERS = [
+	"__NEXT_DATA__",
+	"__NUXT__",
+	"window.__",
+	"bundle.js",
+	"app.js",
+	'id="root"></div>',
+	'id="app"></div>',
+	'id="__next"></div>',
+	"react",
+	"vue",
+	"angular",
+];
+
 /**
  * Crawl homepage + ancestor path pages, extract internal links.
  * Also follows one level of discovered links for broader coverage.
+ * Detects SPAs and bot blocking.
  */
 async function crawlDemoLinks(
 	domain: string,
 	deadPath: string,
-): Promise<DemoPage[]> {
+): Promise<CrawlResult> {
 	const baseUrl = `https://${domain}`;
 	const seen = new Set<string>();
 	const pages: DemoPage[] = [];
+	let spaDetected = false;
+	let blocked: string | undefined;
 
 	// Seed pages: homepage + ancestor paths
 	const seedPaths = ["/"];
@@ -507,8 +753,16 @@ async function crawlDemoLinks(
 
 	for (const seedPath of seedPaths) {
 		if (pages.length >= DEMO_MAX_URLS) break;
-		const html = await fetchDemoText(baseUrl + seedPath);
-		if (!html) continue;
+		const resp = await fetchDemoResponse(baseUrl + seedPath);
+
+		// Check for bot blocking on homepage
+		if (seedPath === "/" && !resp.text) {
+			const blockMsg = detectBlockedResponse(resp.status, resp.text);
+			if (blockMsg) blocked = blockMsg;
+		}
+
+		if (!resp.text || resp.status < 200 || resp.status >= 400) continue;
+		const html = resp.text;
 
 		const seedTitle = extractHtmlTitle(html);
 		const seedUrl = baseUrl + seedPath;
@@ -518,6 +772,16 @@ async function crawlDemoLinks(
 		}
 
 		const links = extractInternalLinks(html, domain);
+
+		// SPA detection: few internal links + script tags with SPA markers
+		if (seedPath === "/" && links.length < 3) {
+			const lowerHtml = html.toLowerCase();
+			const hasScripts = lowerHtml.includes("<script");
+			if (hasScripts && SPA_MARKERS.some((m) => lowerHtml.includes(m.toLowerCase()))) {
+				spaDetected = true;
+			}
+		}
+
 		for (const link of links) {
 			if (seen.has(link.url) || pages.length >= DEMO_MAX_URLS) continue;
 			seen.add(link.url);
@@ -546,7 +810,7 @@ async function crawlDemoLinks(
 		}
 	}
 
-	return pages;
+	return { pages, spaDetected, blocked };
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,28 +265,30 @@ async function discoverDemoPages(
 	}
 
 	// 3. Fallback: crawl HTML links
+	let spaDetected = false;
 	if (Date.now() < deadline) {
 		const crawlResult = await crawlDemoLinks(effectiveDomain, deadPath);
-		if (crawlResult.pages.length > 0) {
+		if (crawlResult.pages.length > 0 && !crawlResult.spaDetected) {
 			return { pages: crawlResult.pages, source: "crawl" };
 		}
-		if (crawlResult.spaDetected) {
-			return {
-				pages: [],
-				source: "none",
-				error:
-					"This site appears to be a single-page application (SPA) that renders content with JavaScript. We can only discover pages from server-rendered HTML, sitemaps, or llms.txt.",
-			};
-		}
+		spaDetected = crawlResult.spaDetected;
 		if (crawlResult.blocked) blockedReason = crawlResult.blocked;
 	}
 
-	// All methods failed — use llms.txt fallback if we had one
+	// All methods failed — use llms.txt fallback if we had one (even for SPAs)
 	if (llmsFallbackPages && llmsFallbackPages.length > 0) {
 		return { pages: llmsFallbackPages, source: "llms.txt" };
 	}
 
 	// Return with best error
+	if (spaDetected) {
+		return {
+			pages: [],
+			source: "none",
+			error:
+				"This site appears to be a single-page application (SPA) that renders content with JavaScript. We can only discover pages from server-rendered HTML, sitemaps, or llms.txt.",
+		};
+	}
 	if (blockedReason) {
 		return { pages: [], source: "none", error: blockedReason };
 	}
@@ -329,8 +331,8 @@ async function fetchLlmsTxt(
 		} catch {}
 	}
 
-	// Check for bot blocking
-	if (!resp.text && resp.status > 0) {
+	// Check for bot blocking (check even when body exists — WAF markers are in HTML)
+	if (resp.status > 0 && (resp.status >= 400 || !resp.text)) {
 		const blockMsg = detectBlockedResponse(resp.status, resp.text);
 		if (blockMsg) blocked = blockMsg;
 	}
@@ -668,18 +670,18 @@ async function fetchDemoSitemap(
 	depth: number,
 	filterDomain?: string,
 ): Promise<DemoPage[]> {
-	const xml = await fetchDemoSitemapXml(url);
-	if (!xml) {
-		// Try as plain-text sitemap (one URL per line, e.g. sitemap.txt)
-		if (url.endsWith(".txt") || url.endsWith("/sitemap.txt")) {
-			const text = await fetchDemoText(url);
-			if (text) {
-				const pages = parsePlainTextSitemap(text, filterDomain);
-				if (pages.length > 0) return pages;
-			}
+	// Plain-text sitemaps: skip XML parsing entirely
+	if (url.endsWith(".txt")) {
+		const text = await fetchDemoText(url);
+		if (text) {
+			const pages = parsePlainTextSitemap(text, filterDomain);
+			if (pages.length > 0) return pages;
 		}
 		return [];
 	}
+
+	const xml = await fetchDemoSitemapXml(url);
+	if (!xml) return [];
 
 	if (!xml.includes("<sitemapindex")) {
 		return extractDemoLocs(xml, "url")
@@ -714,19 +716,12 @@ type CrawlResult = {
 	blocked?: string;
 };
 
-/** SPA framework indicators in HTML source */
+/** SPA indicators: empty root divs with no server-rendered content */
 const SPA_MARKERS = [
-	"__NEXT_DATA__",
-	"__NUXT__",
-	"window.__",
-	"bundle.js",
-	"app.js",
 	'id="root"></div>',
 	'id="app"></div>',
 	'id="__next"></div>',
-	"react",
-	"vue",
-	"angular",
+	'id="__nuxt"></div>',
 ];
 
 /**
@@ -756,7 +751,7 @@ async function crawlDemoLinks(
 		const resp = await fetchDemoResponse(baseUrl + seedPath);
 
 		// Check for bot blocking on homepage
-		if (seedPath === "/" && !resp.text) {
+		if (seedPath === "/" && (resp.status >= 400 || !resp.text)) {
 			const blockMsg = detectBlockedResponse(resp.status, resp.text);
 			if (blockMsg) blocked = blockMsg;
 		}
@@ -773,11 +768,11 @@ async function crawlDemoLinks(
 
 		const links = extractInternalLinks(html, domain);
 
-		// SPA detection: few internal links + script tags with SPA markers
-		if (seedPath === "/" && links.length < 3) {
+		// SPA detection: very few internal links + empty root container divs
+		// Only triggers on truly empty shells, not SSR sites with hydration
+		if (seedPath === "/" && links.length < 2) {
 			const lowerHtml = html.toLowerCase();
-			const hasScripts = lowerHtml.includes("<script");
-			if (hasScripts && SPA_MARKERS.some((m) => lowerHtml.includes(m.toLowerCase()))) {
+			if (SPA_MARKERS.some((m) => lowerHtml.includes(m))) {
 				spaDetected = true;
 			}
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,33 +90,94 @@ app.get("/api/demo/sitemap", async (c) => {
 		return c.json({ error: "Invalid domain" }, 400);
 	}
 
-	const sitemapUrl = `https://${domain}/sitemap.xml`;
-
 	try {
-		const pages = await fetchDemoSitemap(sitemapUrl, deadPath, 0);
-		return c.json({ domain, pages });
+		const pages = await discoverDemoPages(domain, deadPath);
+		return c.json({ domain, pages, source: pages.length > 0 ? "sitemap" : "none" });
 	} catch {
-		return c.json({ domain, pages: [], error: "Could not fetch sitemap" });
+		return c.json({ domain, pages: [], error: "Could not discover pages" });
 	}
 });
 
+// ── Demo page discovery constants ──
 const DEMO_TIMEOUT_MS = 8_000;
 const DEMO_MAX_URLS = 500;
 const DEMO_MAX_DEPTH = 2;
 const DEMO_MAX_CHILDREN = 5;
+const DEMO_USER_AGENT = "agent-404-bot/1.0 (demo)";
 
-async function fetchDemoSitemapXml(url: string): Promise<string | null> {
+// Common sitemap paths to try (in order)
+const SITEMAP_PATHS = [
+	"/sitemap.xml",
+	"/sitemap_index.xml",
+	"/sitemap/sitemap.xml",
+	"/sitemap/index.xml",
+	"/wp-sitemap.xml",
+];
+
+/**
+ * Main discovery pipeline: sitemap → robots.txt → HTML crawl fallback.
+ */
+async function discoverDemoPages(
+	domain: string,
+	deadPath: string,
+): Promise<{ url: string; title: string }[]> {
+	// 1. Try sitemaps (from robots.txt + common paths)
+	const sitemapUrls = await findSitemapUrls(domain);
+	for (const sitemapUrl of sitemapUrls) {
+		const pages = await fetchDemoSitemap(sitemapUrl, deadPath, 0);
+		if (pages.length > 0) return pages;
+	}
+
+	// 2. Fallback: crawl HTML links from the homepage and nearby pages
+	return await crawlDemoLinks(domain, deadPath);
+}
+
+/**
+ * Find sitemap URLs by checking robots.txt, then falling back to common paths.
+ */
+async function findSitemapUrls(domain: string): Promise<string[]> {
+	const found: string[] = [];
+	const seen = new Set<string>();
+
+	// Check robots.txt for Sitemap directives
+	const robotsTxt = await fetchDemoText(`https://${domain}/robots.txt`);
+	if (robotsTxt) {
+		const sitemapRegex = /^Sitemap:\s*(\S+)/gim;
+		let match: RegExpExecArray | null;
+		while ((match = sitemapRegex.exec(robotsTxt)) !== null) {
+			const url = match[1].trim();
+			if (url.startsWith("https://") && !seen.has(url)) {
+				seen.add(url);
+				found.push(url);
+			}
+		}
+	}
+
+	// Add common paths not already discovered
+	for (const path of SITEMAP_PATHS) {
+		const url = `https://${domain}${path}`;
+		if (!seen.has(url)) {
+			seen.add(url);
+			found.push(url);
+		}
+	}
+
+	return found;
+}
+
+/**
+ * Fetch a URL and return text, or null on failure.
+ */
+async function fetchDemoText(url: string): Promise<string | null> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), DEMO_TIMEOUT_MS);
 	try {
 		const resp = await fetch(url, {
-			headers: { "User-Agent": "agent-404-bot/1.0 (demo)" },
+			headers: { "User-Agent": DEMO_USER_AGENT },
 			signal: controller.signal,
+			redirect: "follow",
 		});
 		if (!resp.ok) return null;
-		const contentType = resp.headers.get("content-type") || "";
-		// Reject HTML responses (some sites return 200 with an HTML 404 page)
-		if (contentType.includes("text/html")) return null;
 		return await resp.text();
 	} catch {
 		return null;
@@ -126,27 +187,51 @@ async function fetchDemoSitemapXml(url: string): Promise<string | null> {
 }
 
 /**
- * Score a child sitemap URL by how relevant it is to the dead URL path.
- * Higher = more relevant.
+ * Fetch a URL expecting XML. Rejects HTML responses.
+ */
+async function fetchDemoSitemapXml(url: string): Promise<string | null> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), DEMO_TIMEOUT_MS);
+	try {
+		const resp = await fetch(url, {
+			headers: { "User-Agent": DEMO_USER_AGENT },
+			signal: controller.signal,
+			redirect: "follow",
+		});
+		if (!resp.ok) return null;
+		const contentType = resp.headers.get("content-type") || "";
+		if (contentType.includes("text/html")) return null;
+		const text = await resp.text();
+		// Double-check: some servers return HTML with XML content-type
+		if (text.trimStart().startsWith("<!DOCTYPE") || text.trimStart().startsWith("<html")) return null;
+		return text;
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+/**
+ * Score a child sitemap URL by relevance to the dead URL path.
  */
 function scoreChildSitemap(childUrl: string, deadPath: string): number {
 	const childLower = childUrl.toLowerCase();
-	const deadLower = deadPath.toLowerCase();
-	const deadSegments = deadLower.split("/").filter(Boolean);
+	const deadSegments = deadPath.toLowerCase().split("/").filter(Boolean);
 	if (deadSegments.length === 0) return 0;
 
 	let score = 0;
-	// Bonus for each dead URL segment that appears in the child sitemap URL
 	for (const seg of deadSegments) {
 		if (seg.length > 2 && childLower.includes(seg)) score += 2;
 	}
-	// Bonus for path prefix match (e.g., dead=/docs/start, child URL contains /docs/)
 	const deadPrefix = "/" + deadSegments[0] + "/";
 	if (childLower.includes(deadPrefix)) score += 3;
-
 	return score;
 }
 
+/**
+ * Recursively fetch and parse sitemaps, prioritizing relevant children.
+ */
 async function fetchDemoSitemap(
 	url: string,
 	deadPath: string,
@@ -155,19 +240,18 @@ async function fetchDemoSitemap(
 	const xml = await fetchDemoSitemapXml(url);
 	if (!xml) return [];
 
-	// Not a sitemap index — extract URLs directly
+	// Regular sitemap — extract URLs directly
 	if (!xml.includes("<sitemapindex")) {
 		return extractDemoLocs(xml, "url")
 			.slice(0, DEMO_MAX_URLS)
 			.map((loc) => ({ url: loc, title: demoTitleFromUrl(loc) }));
 	}
 
-	// Sitemap index — prioritize children by relevance to the dead URL
+	// Sitemap index — prioritize children by relevance
 	if (depth >= DEMO_MAX_DEPTH) return [];
 	const childLocs = extractDemoLocs(xml, "sitemap");
 	if (childLocs.length === 0) return [];
 
-	// Score and sort children by relevance, falling back to original order
 	const scored = childLocs.map((loc, i) => ({
 		loc,
 		score: scoreChildSitemap(loc, deadPath),
@@ -176,13 +260,102 @@ async function fetchDemoSitemap(
 	scored.sort((a, b) => b.score - a.score || a.idx - b.idx);
 	const topChildren = scored.slice(0, DEMO_MAX_CHILDREN);
 
-	// Fetch top children in parallel
 	const results = await Promise.all(
 		topChildren.map((child) => fetchDemoSitemap(child.loc, deadPath, depth + 1)),
 	);
+	return results.flat().slice(0, DEMO_MAX_URLS);
+}
 
-	const allPages = results.flat();
-	return allPages.slice(0, DEMO_MAX_URLS);
+/**
+ * HTML crawl fallback: fetch homepage + a few relevant pages, extract internal links.
+ */
+async function crawlDemoLinks(
+	domain: string,
+	deadPath: string,
+): Promise<{ url: string; title: string }[]> {
+	const baseUrl = `https://${domain}`;
+	const seen = new Set<string>();
+	const pages: { url: string; title: string }[] = [];
+
+	// Seed pages to crawl: homepage + path prefix pages
+	const seedPaths = ["/"];
+	const deadSegments = deadPath.split("/").filter(Boolean);
+	// Add ancestor paths (e.g., /docs/guides/start → try /docs, /docs/guides)
+	for (let i = 1; i <= Math.min(deadSegments.length, 3); i++) {
+		seedPaths.push("/" + deadSegments.slice(0, i).join("/"));
+	}
+
+	for (const seedPath of seedPaths) {
+		if (pages.length >= DEMO_MAX_URLS) break;
+		const html = await fetchDemoText(baseUrl + seedPath);
+		if (!html) continue;
+
+		// Extract page title
+		const seedTitle = extractHtmlTitle(html);
+		const seedUrl = baseUrl + seedPath;
+		if (!seen.has(seedUrl)) {
+			seen.add(seedUrl);
+			pages.push({ url: seedUrl, title: seedTitle });
+		}
+
+		// Extract all internal links
+		const links = extractInternalLinks(html, domain);
+		for (const link of links) {
+			if (seen.has(link.url) || pages.length >= DEMO_MAX_URLS) continue;
+			seen.add(link.url);
+			pages.push(link);
+		}
+	}
+
+	return pages;
+}
+
+/**
+ * Extract <title> from HTML.
+ */
+function extractHtmlTitle(html: string): string {
+	const match = /<title[^>]*>([^<]+)<\/title>/i.exec(html);
+	return match ? match[1].trim() : "";
+}
+
+/**
+ * Extract internal links with their anchor text from HTML.
+ */
+function extractInternalLinks(
+	html: string,
+	domain: string,
+): { url: string; title: string }[] {
+	const links: { url: string; title: string }[] = [];
+	const seen = new Set<string>();
+	// Match <a> tags, capture href and inner text
+	const regex = /<a\s[^>]*href=["']([^"'#]+)["'][^>]*>([^<]*(?:<[^/a][^>]*>[^<]*)*)<\/a>/gi;
+	let match: RegExpExecArray | null;
+	while ((match = regex.exec(html)) !== null) {
+		let href = match[1].trim();
+		const text = match[2].replace(/<[^>]+>/g, "").trim();
+
+		// Resolve relative URLs
+		if (href.startsWith("/")) {
+			href = `https://${domain}${href}`;
+		}
+
+		// Only keep same-domain HTTPS links
+		try {
+			const parsed = new URL(href);
+			if (parsed.hostname !== domain && !parsed.hostname.endsWith("." + domain)) continue;
+			if (parsed.protocol !== "https:") continue;
+			// Skip anchors, query-only, assets, and common non-page paths
+			const path = parsed.pathname;
+			if (/\.(css|js|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|pdf|zip)$/i.test(path)) continue;
+			const canonical = parsed.origin + path.replace(/\/+$/, "");
+			if (seen.has(canonical)) continue;
+			seen.add(canonical);
+			links.push({ url: canonical, title: text || demoTitleFromUrl(canonical) });
+		} catch {
+			continue;
+		}
+	}
+	return links;
 }
 
 function extractDemoLocs(xml: string, parentTag: string): string[] {

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import app from "../src/index.js";
+
+// Helper to call the demo sitemap endpoint
+async function discoverPages(domain: string, path = "") {
+	let url = `/api/demo/sitemap?domain=${encodeURIComponent(domain)}`;
+	if (path) url += `&path=${encodeURIComponent(path)}`;
+	const res = await app.request(url, {
+		headers: { "x-forwarded-for": `test-${Math.random()}` },
+	});
+	return res.json() as Promise<{
+		domain: string;
+		pages: { url: string; title: string; description?: string }[];
+		source: string;
+		error?: string;
+	}>;
+}
+
+// ── Test data ──
+
+const LLMS_TXT_WITH_PAGES = `# Example Docs
+
+## Pages
+- [Auth Guide](https://example.com/docs/auth): How to authenticate
+- [Billing](https://example.com/docs/billing): Manage billing
+- [Users](https://example.com/docs/users): User management
+`;
+
+const LLMS_TXT_CHILDREN_ONLY = `# Example Platform
+
+## Documentation
+- [Workers Docs](https://example.com/workers/llms.txt): Workers documentation
+- [Pages Docs](https://example.com/pages/llms.txt): Pages documentation
+- [R2 Docs](https://example.com/r2/llms.txt): R2 storage documentation
+`;
+
+const LLMS_TXT_MIXED = `# Example Mixed
+
+## Overview
+- [Getting Started](https://example.com/docs/start): Get started
+- [API Reference](https://example.com/docs/api): API docs
+
+## Product Docs
+- [Workers](https://example.com/workers/llms.txt): Workers docs
+`;
+
+const CHILD_LLMS_TXT_WORKERS = `# Workers
+
+## Pages
+- [Worker API](https://example.com/workers/api): Worker API reference
+- [Worker Config](https://example.com/workers/config): Configuration guide
+`;
+
+const LLMS_TXT_BLOG_ONLY = `# Example Blog
+
+## Recent Posts
+- [Launching v2](https://example.com/blog/launching-v2): We launched v2
+- [Performance Tips](https://example.com/blog/perf-tips): Speed up your app
+`;
+
+const SIMPLE_SITEMAP = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/docs/auth</loc></url>
+  <url><loc>https://example.com/docs/billing</loc></url>
+  <url><loc>https://example.com/docs/messaging</loc></url>
+</urlset>`;
+
+const PLAIN_TEXT_SITEMAP = `https://example.com/docs/auth
+https://example.com/docs/billing
+https://example.com/docs/users
+`;
+
+const HOMEPAGE_HTML = `<!DOCTYPE html>
+<html><head><title>Example</title></head>
+<body>
+<nav>
+  <a href="/docs">Docs</a>
+  <a href="/blog">Blog</a>
+  <a href="/about">About</a>
+  <a href="/pricing">Pricing</a>
+  <a href="/contact">Contact</a>
+</nav>
+</body></html>`;
+
+const SPA_HTML = `<!DOCTYPE html>
+<html><head><title>SPA App</title></head>
+<body>
+<div id="root"></div>
+<script src="/bundle.js"></script>
+</body></html>`;
+
+const CLOUDFLARE_CHALLENGE = `<!DOCTYPE html>
+<html><head><title>Just a moment...</title></head>
+<body>
+<div class="cf-browser-verification">
+  <div id="__cf_chl_"></div>
+</div>
+</body></html>`;
+
+// ── Mock helper ──
+
+/**
+ * Creates a fetch mock that matches URLs by substring and returns configured responses.
+ * Uses a function-based matcher so multiple calls to the same URL each get a fresh Response.
+ * Unmatched URLs return 404.
+ */
+function mockFetch(
+	responses: Array<{
+		match: string;
+		status: number;
+		body: string;
+		headers?: Record<string, string>;
+		url?: string; // Override resp.url (for redirect simulation)
+	}>,
+) {
+	vi.spyOn(globalThis, "fetch").mockImplementation(async (input: any) => {
+		const fetchUrl = typeof input === "string" ? input : input.url;
+
+		for (const r of responses) {
+			if (fetchUrl.includes(r.match)) {
+				const resp = new Response(r.body, {
+					status: r.status,
+					headers: { "content-type": "text/plain", ...r.headers },
+				});
+				if (r.url) {
+					Object.defineProperty(resp, "url", { value: r.url });
+				}
+				return resp;
+			}
+		}
+		return new Response("Not Found", { status: 404 });
+	});
+}
+
+// ── Tests ──
+
+describe("Demo page discovery", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("Input validation", () => {
+		it("rejects missing domain", async () => {
+			const res = await app.request("/api/demo/sitemap", {
+				headers: { "x-forwarded-for": "val-1" },
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("rejects domains with slashes", async () => {
+			const res = await app.request("/api/demo/sitemap?domain=example.com/foo", {
+				headers: { "x-forwarded-for": "val-2" },
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("rejects private hosts", async () => {
+			const res = await app.request("/api/demo/sitemap?domain=localhost", {
+				headers: { "x-forwarded-for": "val-3" },
+			});
+			expect(res.status).toBe(400);
+		});
+	});
+
+	describe("llms.txt discovery", () => {
+		it("returns pages from llms.txt with source field", async () => {
+			mockFetch([
+				{ match: "example.com/llms.txt", status: 200, body: LLMS_TXT_WITH_PAGES },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/foo");
+			expect(data.source).toBe("llms.txt");
+			expect(data.pages.length).toBe(3);
+			expect(data.pages[0].url).toBe("https://example.com/docs/auth");
+			expect(data.pages[0].title).toBe("Auth Guide");
+			expect(data.error).toBeUndefined();
+		});
+
+		it("follows child llms.txt when root has only children", async () => {
+			mockFetch([
+				{ match: "example.com/llms.txt", status: 200, body: LLMS_TXT_CHILDREN_ONLY },
+				{ match: "/workers/llms.txt", status: 200, body: CHILD_LLMS_TXT_WORKERS },
+			]);
+
+			const data = await discoverPages("example.com", "/workers/api");
+			expect(data.source).toBe("llms.txt");
+			expect(data.pages.some((p) => p.url.includes("/workers/api"))).toBe(true);
+		});
+
+		it("merges pages and children in mixed llms.txt", async () => {
+			mockFetch([
+				{ match: "example.com/llms.txt", status: 200, body: LLMS_TXT_MIXED },
+				{ match: "/workers/llms.txt", status: 200, body: CHILD_LLMS_TXT_WORKERS },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/start");
+			expect(data.source).toBe("llms.txt");
+			const urls = data.pages.map((p) => p.url);
+			// Direct pages
+			expect(urls).toContain("https://example.com/docs/start");
+			expect(urls).toContain("https://example.com/docs/api");
+			// Merged child pages
+			expect(urls).toContain("https://example.com/workers/api");
+			expect(urls).toContain("https://example.com/workers/config");
+		});
+	});
+
+	describe("Relevance check — llms.txt fallthrough", () => {
+		it("skips irrelevant llms.txt and falls through to sitemap", async () => {
+			mockFetch([
+				// Root llms.txt returns blog pages (not /docs/)
+				{ match: "example.com/llms.txt", status: 200, body: LLMS_TXT_BLOG_ONLY },
+				// Path-prefix sitemap has docs pages
+				{ match: "/docs/sitemap.xml", status: 200, body: SIMPLE_SITEMAP },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/message");
+			expect(data.source).toBe("sitemap");
+			expect(data.pages.some((p) => p.url.includes("/docs/messaging"))).toBe(true);
+		});
+
+		it("uses llms.txt fallback when sitemap and crawl also fail", async () => {
+			mockFetch([
+				// Root llms.txt returns blog pages (not /docs/)
+				{ match: "example.com/llms.txt", status: 200, body: LLMS_TXT_BLOG_ONLY },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/message");
+			// Should fall back to the blog pages since nothing else worked
+			expect(data.source).toBe("llms.txt");
+			expect(data.pages.length).toBe(2);
+		});
+	});
+
+	describe("Sitemap discovery", () => {
+		it("parses XML sitemap and returns source", async () => {
+			mockFetch([
+				{ match: "sitemap.xml", status: 200, body: SIMPLE_SITEMAP },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/foo");
+			expect(data.source).toBe("sitemap");
+			expect(data.pages.length).toBe(3);
+		});
+
+		it("parses plain-text sitemap (one URL per line)", async () => {
+			mockFetch([
+				{ match: "sitemap.txt", status: 200, body: PLAIN_TEXT_SITEMAP },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/foo");
+			expect(data.source).toBe("sitemap");
+			expect(data.pages.length).toBe(3);
+			expect(data.pages[0].url).toBe("https://example.com/docs/auth");
+		});
+	});
+
+	describe("HTML crawl fallback", () => {
+		it("crawls HTML links when llms.txt and sitemap fail", async () => {
+			mockFetch([
+				{ match: "https://example.com/", status: 200, body: HOMEPAGE_HTML },
+			]);
+
+			const data = await discoverPages("example.com");
+			expect(data.source).toBe("crawl");
+			expect(data.pages.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe("Bot-block detection", () => {
+		it("detects Cloudflare challenge page", async () => {
+			mockFetch([
+				{ match: "example.com", status: 403, body: CLOUDFLARE_CHALLENGE },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/foo");
+			expect(data.pages).toHaveLength(0);
+			expect(data.source).toBe("none");
+			expect(data.error).toContain("Cloudflare");
+		});
+
+		it("detects 403 Forbidden", async () => {
+			mockFetch([
+				{ match: "example.com", status: 403, body: "Forbidden" },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/foo");
+			expect(data.pages).toHaveLength(0);
+			expect(data.error).toContain("403");
+		});
+
+		it("detects 401 Unauthorized", async () => {
+			mockFetch([
+				{ match: "example.com", status: 401, body: "Unauthorized" },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/foo");
+			expect(data.pages).toHaveLength(0);
+			expect(data.error).toContain("authentication");
+		});
+
+		it("detects 429 rate limiting", async () => {
+			mockFetch([
+				{ match: "example.com", status: 429, body: "Too Many Requests" },
+			]);
+
+			const data = await discoverPages("example.com", "/docs/foo");
+			expect(data.pages).toHaveLength(0);
+			expect(data.error).toContain("rate-limiting");
+		});
+	});
+
+	describe("SPA detection", () => {
+		it("detects SPA with empty root div and no links", async () => {
+			mockFetch([
+				{ match: "https://example.com/", status: 200, body: SPA_HTML },
+			]);
+
+			const data = await discoverPages("example.com");
+			expect(data.source).toBe("none");
+			expect(data.error).toContain("single-page application");
+		});
+
+		it("does not falsely detect SSR sites as SPAs", async () => {
+			mockFetch([
+				{ match: "https://example.com/", status: 200, body: HOMEPAGE_HTML },
+			]);
+
+			const data = await discoverPages("example.com");
+			expect(data.source).toBe("crawl");
+			expect(data.error).toBeUndefined();
+		});
+	});
+
+	describe("Response structure", () => {
+		it("always includes source field", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("Not Found", { status: 404 }),
+			);
+
+			const data = await discoverPages("example.com");
+			expect(data.source).toBeDefined();
+			expect(["llms.txt", "sitemap", "crawl", "none"]).toContain(data.source);
+		});
+
+		it("includes error field when discovery fails completely", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("Not Found", { status: 404 }),
+			);
+
+			const data = await discoverPages("example.com");
+			expect(data.error).toBeDefined();
+			expect(typeof data.error).toBe("string");
+		});
+	});
+
+	describe("Cross-domain redirects", () => {
+		it("follows redirect and uses effective domain for llms.txt parsing", async () => {
+			const redirectedLlms = `# Stripe Docs
+- [Payments](https://docs.stripe.example.com/payments): Payment guide
+- [Checkout](https://docs.stripe.example.com/checkout): Checkout guide`;
+
+			mockFetch([
+				{
+					match: "stripe.example.com/llms.txt",
+					status: 200,
+					body: redirectedLlms,
+					url: "https://docs.stripe.example.com/llms.txt",
+				},
+			]);
+
+			const data = await discoverPages("stripe.example.com", "/payments");
+			expect(data.source).toBe("llms.txt");
+			expect(data.pages.some((p) => p.url.includes("docs.stripe.example.com"))).toBe(true);
+		});
+	});
+});

--- a/test/manual-discovery.ts
+++ b/test/manual-discovery.ts
@@ -1,0 +1,42 @@
+import app from "../src/index.js";
+
+async function test(domain: string, path: string, searchFor: string) {
+	let url = `/api/demo/sitemap?domain=${encodeURIComponent(domain)}`;
+	if (path) url += `&path=${encodeURIComponent(path)}`;
+	const res = await app.request(url);
+	const data = (await res.json()) as any;
+	console.log(`\n=== ${domain}${path} ===`);
+	console.log(`source: ${data.source}`);
+	console.log(`pages: ${data.pages?.length}`);
+	console.log(`error: ${data.error || "none"}`);
+
+	// Search for target page
+	const found = data.pages?.filter((p: any) => p.url.toLowerCase().includes(searchFor.toLowerCase()));
+	if (found?.length > 0) {
+		console.log(`FOUND target "${searchFor}":`);
+		for (const p of found.slice(0, 5)) {
+			console.log(`  ${p.url} — ${p.title}`);
+		}
+	} else {
+		console.log(`TARGET "${searchFor}" NOT FOUND in ${data.pages?.length} pages`);
+		// Show pages that are closest (contain partial match)
+		const partial = data.pages?.filter((p: any) => {
+			const u = p.url.toLowerCase();
+			return searchFor.split("/").some((s: string) => s.length > 3 && u.includes(s));
+		}).slice(0, 5);
+		if (partial?.length > 0) {
+			console.log("Partial matches:");
+			for (const p of partial) {
+				console.log(`  ${p.url} — ${p.title}`);
+			}
+		}
+	}
+}
+
+async function main() {
+	await test("developers.cloudflare.com", "/work/", "workers");
+	await test("www.twilio.com", "/docs/message", "messaging");
+	await test("vercel.com", "/docs/deploy", "deploy-hooks");
+}
+
+main().catch(console.error);

--- a/test/matcher.test.ts
+++ b/test/matcher.test.ts
@@ -66,6 +66,41 @@ describe("findSuggestions", () => {
 		expect(results).toEqual([]);
 	});
 
+	it("should match prefix segments (work → workers)", () => {
+		const cfPages = [
+			makePage("https://example.com/workers/api", "Workers API"),
+			makePage("https://example.com/workers/config", "Workers Config"),
+			makePage("https://example.com/pages/deploy", "Pages Deploy"),
+		];
+		const results = findSuggestions("https://example.com/work", cfPages);
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0].url).toContain("/workers/");
+	});
+
+	it("should match prefix keywords (message → messaging)", () => {
+		const twilioPages = [
+			makePage("https://example.com/docs/messaging", "Messaging API"),
+			makePage("https://example.com/docs/voice", "Voice API"),
+			makePage("https://example.com/docs/video", "Video API"),
+		];
+		const results = findSuggestions("https://example.com/docs/message", twilioPages);
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0].url).toContain("/messaging");
+	});
+
+	it("should match compound segments (deploy → deploy-hooks)", () => {
+		const vercelPages = [
+			makePage("https://example.com/docs/deploy-hooks", "Deploy Hooks"),
+			makePage("https://example.com/docs/deployments", "Deployments"),
+			makePage("https://example.com/docs/functions", "Functions"),
+		];
+		const results = findSuggestions("https://example.com/docs/deploy", vercelPages);
+		expect(results.length).toBeGreaterThan(0);
+		// Both deploy-hooks and deployments should match
+		const urls = results.map((r) => r.url);
+		expect(urls.some((u) => u.includes("deploy"))).toBe(true);
+	});
+
 	it("should rank similar paths higher", () => {
 		const results = findSuggestions("https://example.com/docs/v3/billing", pages);
 		expect(results[0].url).toBe("https://example.com/docs/v3/billing");


### PR DESCRIPTION
- Accept dead URL path to prioritize relevant child sitemaps
- Score child sitemaps by path segment overlap with the dead URL
- Fetch top 5 children in parallel instead of 3 sequentially
- Support 2 levels of sitemap index nesting
- Reject HTML responses (some sites return 200 HTML for missing sitemaps)
- Fixes demo returning no results for sites like mongodb.com