### PR TITLE
Add dashboard with suggestion logs and match quality stats

### DIFF
--- a/migrations/0003_dashboard.sql
+++ b/migrations/0003_dashboard.sql
@@ -1,0 +1,7 @@
+-- Add scoring metadata to suggestion_logs for dashboard analytics
+ALTER TABLE suggestion_logs ADD COLUMN IF NOT EXISTS scores TEXT;
+ALTER TABLE suggestion_logs ADD COLUMN IF NOT EXISTS match_types TEXT;
+
+-- Index for efficient dashboard queries
+CREATE INDEX IF NOT EXISTS idx_suggestion_logs_site_created
+  ON suggestion_logs (site_id, created_at DESC);

--- a/src/api/routes/analyze.ts
+++ b/src/api/routes/analyze.ts
@@ -1,0 +1,32 @@
+import { Hono } from "hono";
+import type { PostgresStorage } from "../../storage/postgres.js";
+import { analyzeSite } from "../../engine/analyzer.js";
+
+type Env = { Variables: { storage: PostgresStorage; siteId: string } };
+
+const analyze = new Hono<Env>();
+
+// Analyze a site for broken internal links and orphan pages
+analyze.post("/", async (c) => {
+	const siteId = c.get("siteId");
+	const storage = c.get("storage");
+
+	const site = await storage.getSite(siteId);
+	if (!site) {
+		return c.json({ error: "Site not found" }, 404);
+	}
+
+	const pages = await storage.getPages(siteId);
+	if (pages.length === 0) {
+		return c.json({ error: "No pages indexed for this site" }, 400);
+	}
+
+	const report = await analyzeSite(
+		pages.map((p) => ({ url: p.url, title: p.title })),
+		site.domain,
+	);
+
+	return c.json(report);
+});
+
+export { analyze };

--- a/src/api/routes/suggest.ts
+++ b/src/api/routes/suggest.ts
@@ -33,13 +33,17 @@ suggest.post("/", async (c) => {
 
 	const suggestions = findSuggestions(body.url, pages, deadUrlEmbedding);
 
-	// Log asynchronously
+	// Log asynchronously (include scores + match types for dashboard)
 	if (suggestions.length > 0) {
+		const scores = JSON.stringify(suggestions.map((s) => s.score));
+		const matchTypes = JSON.stringify(suggestions.map((s) => s.matchType));
 		storage
 			.recordSuggestionServed(
 				siteId,
 				body.url,
 				suggestions.map((s) => s.url),
+				scores,
+				matchTypes,
 			)
 			.catch(() => {});
 	}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,0 +1,108 @@
+import type { DashboardData } from "./types.js";
+
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}
+
+function truncate(str: string, max: number): string {
+	return str.length > max ? str.slice(0, max - 1) + "\u2026" : str;
+}
+
+export function dashboardHtml(data: DashboardData): string {
+	const recentRows = data.recentLogs
+		.map((log) => {
+			const topSuggestion = log.suggestedUrls[0] || "\u2014";
+			const scores = log.scores ? JSON.parse(log.scores) : [];
+			const topScore = scores[0] != null ? (scores[0] as number).toFixed(3) : "\u2014";
+			const time = new Date(log.createdAt).toLocaleString("en-US", {
+				month: "short",
+				day: "numeric",
+				hour: "2-digit",
+				minute: "2-digit",
+			});
+			return `<tr>
+				<td title="${escapeHtml(log.deadUrl)}">${escapeHtml(truncate(log.deadUrl, 60))}</td>
+				<td title="${escapeHtml(topSuggestion)}">${escapeHtml(truncate(topSuggestion, 60))}</td>
+				<td>${topScore}</td>
+				<td>${time}</td>
+			</tr>`;
+		})
+		.join("\n");
+
+	const mq = data.matchQuality;
+	const total =
+		mq.matchTypeDistribution.moved +
+		mq.matchTypeDistribution.similar +
+		mq.matchTypeDistribution.related;
+	const pct = (n: number) => (total > 0 ? Math.round((n / total) * 100) : 0);
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dashboard \u2014 ${escapeHtml(data.domain)} \u2014 agent-404</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+:root {
+  --bg: #0a0a0b; --surface: #141416; --border: #27272a;
+  --text: #fafafa; --text-secondary: #a1a1aa;
+  --accent: #3b82f6; --green: #22c55e; --orange: #f97316;
+}
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: var(--bg); color: var(--text); padding: 2rem; max-width: 1000px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.subtitle { color: var(--text-secondary); margin-bottom: 2rem; }
+.stats { display: flex; gap: 1rem; margin-bottom: 2rem; flex-wrap: wrap; }
+.stat-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.5rem; flex: 1; min-width: 150px; }
+.stat-card .label { color: var(--text-secondary); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
+.stat-card .value { font-size: 1.5rem; font-weight: 700; margin-top: 0.25rem; }
+h2 { font-size: 1.1rem; margin-bottom: 1rem; margin-top: 2rem; }
+table { width: 100%; border-collapse: collapse; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+th, td { text-align: left; padding: 0.6rem 1rem; border-bottom: 1px solid var(--border); font-size: 0.85rem; }
+th { color: var(--text-secondary); font-weight: 500; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; }
+td { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 300px; }
+tr:last-child td { border-bottom: none; }
+.dist { display: flex; gap: 1.5rem; margin-top: 0.5rem; }
+.dist-item { display: flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; }
+.dist-dot { width: 10px; height: 10px; border-radius: 50%; }
+.dot-moved { background: var(--accent); }
+.dot-similar { background: var(--green); }
+.dot-related { background: var(--orange); }
+.empty { color: var(--text-secondary); padding: 2rem; text-align: center; }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(data.domain)}</h1>
+<p class="subtitle">agent-404 dashboard</p>
+
+<div class="stats">
+  <div class="stat-card"><div class="label">Indexed Pages</div><div class="value">${data.pageCount}</div></div>
+  <div class="stat-card"><div class="label">Suggestions Served</div><div class="value">${data.suggestionsServed}</div></div>
+  <div class="stat-card"><div class="label">Last 24h</div><div class="value">${mq.last24h}</div></div>
+  <div class="stat-card"><div class="label">Last 7d</div><div class="value">${mq.last7d}</div></div>
+  <div class="stat-card"><div class="label">Last 30d</div><div class="value">${mq.last30d}</div></div>
+</div>
+
+<h2>Match Type Distribution</h2>
+<div class="dist">
+  <div class="dist-item"><span class="dist-dot dot-moved"></span> Moved ${pct(mq.matchTypeDistribution.moved)}%</div>
+  <div class="dist-item"><span class="dist-dot dot-similar"></span> Similar ${pct(mq.matchTypeDistribution.similar)}%</div>
+  <div class="dist-item"><span class="dist-dot dot-related"></span> Related ${pct(mq.matchTypeDistribution.related)}%</div>
+</div>
+
+<h2>Recent Activity</h2>
+${
+	data.recentLogs.length > 0
+		? `<table>
+<thead><tr><th>Dead URL</th><th>Top Suggestion</th><th>Score</th><th>Time</th></tr></thead>
+<tbody>${recentRows}</tbody>
+</table>`
+		: `<div class="empty">No suggestion logs yet.</div>`
+}
+</body>
+</html>`;
+}

--- a/src/engine/analyzer.ts
+++ b/src/engine/analyzer.ts
@@ -1,0 +1,136 @@
+import type { AnalysisReport } from "../types.js";
+
+interface PageInfo {
+	url: string;
+	title: string;
+}
+
+const BATCH_SIZE = 5;
+const BATCH_DELAY_MS = 200;
+const OVERALL_TIMEOUT_MS = 30_000;
+const FETCH_TIMEOUT_MS = 5_000;
+const USER_AGENT = "Mozilla/5.0 (compatible; agent-404-analyzer/1.0)";
+
+/** Extract internal <a href> links from HTML */
+function extractInternalLinks(html: string, domain: string): string[] {
+	const links: string[] = [];
+	const hrefRe = /<a\s[^>]*href=["']([^"']+)["']/gi;
+	let match: RegExpExecArray | null;
+	while ((match = hrefRe.exec(html)) !== null) {
+		const href = match[1];
+		try {
+			const url = new URL(href, `https://${domain}`);
+			if (url.hostname === domain || url.hostname === `www.${domain}`) {
+				const normalized = `${url.origin}${url.pathname}`.replace(/\/+$/, "");
+				links.push(normalized);
+			}
+		} catch {
+			// skip invalid URLs
+		}
+	}
+	return links;
+}
+
+/** SSRF protection: block private/internal IPs */
+const BLOCKED_PREFIXES = [
+	"localhost", "127.", "0.0.0.0", "10.",
+	"172.16.", "172.17.", "172.18.", "172.19.",
+	"172.20.", "172.21.", "172.22.", "172.23.",
+	"172.24.", "172.25.", "172.26.", "172.27.",
+	"172.28.", "172.29.", "172.30.", "172.31.",
+	"192.168.", "169.254.", "[::1]", "[fc", "[fd",
+];
+
+function isBlockedHost(hostname: string): boolean {
+	const lower = hostname.toLowerCase();
+	return BLOCKED_PREFIXES.some((b) => lower === b || lower.startsWith(b));
+}
+
+async function fetchPageHtml(url: string): Promise<string | null> {
+	try {
+		const parsed = new URL(url);
+		if (isBlockedHost(parsed.hostname)) return null;
+	} catch {
+		return null;
+	}
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+	try {
+		const resp = await fetch(url, {
+			headers: { "User-Agent": USER_AGENT, Accept: "text/html" },
+			signal: controller.signal,
+			redirect: "follow",
+		});
+		if (!resp.ok) return null;
+		return await resp.text();
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Analyze a site's indexed pages for broken internal links and orphan pages.
+ */
+export async function analyzeSite(
+	pages: PageInfo[],
+	domain: string,
+): Promise<AnalysisReport> {
+	const deadline = Date.now() + OVERALL_TIMEOUT_MS;
+	const pageUrlSet = new Set(pages.map((p) => p.url.replace(/\/+$/, "")));
+	const brokenLinks: AnalysisReport["brokenLinks"] = [];
+	const inboundCount = new Map<string, number>();
+
+	// Initialize inbound counts
+	for (const url of pageUrlSet) {
+		inboundCount.set(url, 0);
+	}
+
+	let pagesAnalyzed = 0;
+
+	// Process in batches
+	for (let i = 0; i < pages.length; i += BATCH_SIZE) {
+		if (Date.now() >= deadline) break;
+
+		const batch = pages.slice(i, i + BATCH_SIZE);
+		const results = await Promise.all(batch.map((p) => fetchPageHtml(p.url)));
+
+		for (let j = 0; j < batch.length; j++) {
+			const html = results[j];
+			if (!html) continue;
+			pagesAnalyzed++;
+
+			const links = extractInternalLinks(html, domain);
+			for (const link of links) {
+				if (pageUrlSet.has(link)) {
+					inboundCount.set(link, (inboundCount.get(link) || 0) + 1);
+				} else {
+					brokenLinks.push({ sourcePage: batch[j].url, targetUrl: link });
+				}
+			}
+		}
+
+		if (i + BATCH_SIZE < pages.length && Date.now() < deadline) {
+			await sleep(BATCH_DELAY_MS);
+		}
+	}
+
+	// Orphans = pages with zero inbound links from other indexed pages
+	const orphanPages = [...inboundCount.entries()]
+		.filter(([, count]) => count === 0)
+		.map(([url]) => url);
+
+	return {
+		domain,
+		analyzedAt: new Date().toISOString(),
+		pagesAnalyzed,
+		brokenLinks,
+		orphanPages,
+	};
+}

--- a/src/engine/matcher.ts
+++ b/src/engine/matcher.ts
@@ -1,4 +1,5 @@
 import type { PageRecord, Suggestion } from "../types.js";
+import { stemToken } from "./stemmer.js";
 
 const SCORE_THRESHOLD = 0.2;
 const MAX_RESULTS = 5;
@@ -171,6 +172,15 @@ function jaccardVersionTolerant(a: string[], b: string[]): number {
 				if (prefixMatch) {
 					matches += 0.7;
 					used.add(prefixMatch);
+				} else {
+					// Stem match: "message" ↔ "messaging" = 0.6
+					const stemMatch = b.find(
+						(bSeg) => !used.has(bSeg) && stemToken(seg) === stemToken(bSeg),
+					);
+					if (stemMatch) {
+						matches += 0.6;
+						used.add(stemMatch);
+					}
 				}
 			}
 		}
@@ -231,10 +241,21 @@ function keywordOverlap(a: Set<string>, b: Set<string>): number {
 			intersection++;
 		} else {
 			// Prefix match: "message" matches "messaging" as 0.7
+			let matched = false;
 			for (const bWord of b) {
 				if (isPrefixMatch(word, bWord)) {
 					intersection += 0.7;
+					matched = true;
 					break;
+				}
+			}
+			// Stem match: "deploy" matches "deployment" as 0.6
+			if (!matched) {
+				for (const bWord of b) {
+					if (stemToken(word) === stemToken(bWord)) {
+						intersection += 0.6;
+						break;
+					}
 				}
 			}
 		}

--- a/src/engine/stemmer.ts
+++ b/src/engine/stemmer.ts
@@ -1,0 +1,32 @@
+/**
+ * Lightweight suffix-stripping stemmer for fuzzy token matching.
+ * Single-pass, ordered longest-first. Result must be >= 3 chars.
+ */
+
+const SUFFIX_RULES: [string, string][] = [
+	["izations", "ize"],
+	["ments", ""],
+	["ment", ""],
+	["ing", ""],
+	["tion", ""],
+	["ers", ""],
+	["ies", "y"],
+	["es", ""],
+	["ed", ""],
+	["er", ""],
+	["ly", ""],
+	["s", ""],
+];
+
+export function stemToken(word: string): string {
+	if (word.length <= 4) return word;
+
+	for (const [suffix, replacement] of SUFFIX_RULES) {
+		if (word.endsWith(suffix)) {
+			const stem = word.slice(0, -suffix.length) + replacement;
+			if (stem.length >= 3) return stem;
+		}
+	}
+
+	return word;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { buildEmbeddingText, generateBatchEmbeddings } from "./engine/embeddings
 import { landingPageHtml } from "./landing.js";
 import { demoPageHtml } from "./demo.js";
 import { analyze } from "./api/routes/analyze.js";
+import { dashboardHtml } from "./dashboard.js";
 
 export type Bindings = {
 	DATABASE_URL: string;
@@ -977,6 +978,38 @@ app.route("/api/suggest", suggest);
 
 app.use("/api/analyze", apiKeyAuth());
 app.route("/api/analyze", analyze);
+
+// Dashboard — server-rendered, authenticated via query param
+app.get("/dashboard", async (c) => {
+	const key = c.req.query("key");
+	if (!key || typeof key !== "string") {
+		return c.text("Missing API key. Use /dashboard?key=YOUR_API_KEY", 401);
+	}
+
+	const dbUrl = c.env?.DATABASE_URL || process.env.DATABASE_URL || process.env.POSTGRES_URL;
+	const storage = new PostgresStorage(dbUrl);
+
+	const site = await storage.getSiteByApiKey(key);
+	if (!site) {
+		return c.text("Invalid API key", 401);
+	}
+
+	const [stats, recentLogs, matchQuality] = await Promise.all([
+		storage.getStats(site.id),
+		storage.getSuggestionLogs(site.id, 20),
+		storage.getMatchQualityStats(site.id),
+	]);
+
+	return c.html(
+		dashboardHtml({
+			domain: site.domain,
+			pageCount: stats.pageCount,
+			suggestionsServed: stats.suggestionsServed,
+			recentLogs,
+			matchQuality,
+		}),
+	);
+});
 
 // Cron: re-crawl sitemaps + prune stale pages
 app.get("/api/cron", async (c) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { pruneStalePages } from "./engine/indexer.js";
 import { buildEmbeddingText, generateBatchEmbeddings } from "./engine/embeddings.js";
 import { landingPageHtml } from "./landing.js";
 import { demoPageHtml } from "./demo.js";
+import { analyze } from "./api/routes/analyze.js";
 
 export type Bindings = {
 	DATABASE_URL: string;
@@ -55,6 +56,7 @@ app.use("*", async (c, next) => {
 app.use("/api/sites", rateLimiter({ windowMs: 60_000, max: 10 }));
 app.use("/api/register", rateLimiter({ windowMs: 60_000, max: 60 }));
 app.use("/api/suggest", rateLimiter({ windowMs: 60_000, max: 60 }));
+app.use("/api/analyze", rateLimiter({ windowMs: 300_000, max: 2 }));
 
 // Landing page
 app.get("/", (c) => c.html(landingPageHtml));
@@ -972,6 +974,9 @@ app.route("/api/register", register);
 
 app.use("/api/suggest", apiKeyAuth());
 app.route("/api/suggest", suggest);
+
+app.use("/api/analyze", apiKeyAuth());
+app.route("/api/analyze", analyze);
 
 // Cron: re-crawl sitemaps + prune stale pages
 app.get("/api/cron", async (c) => {

--- a/src/storage/interface.ts
+++ b/src/storage/interface.ts
@@ -1,4 +1,4 @@
-import type { PageRecord, SiteRecord, SiteStats } from "../types.js";
+import type { PageRecord, SiteRecord, SiteStats, SuggestionLog, MatchQualityStats } from "../types.js";
 
 export interface StorageAdapter {
 	createSite(domain: string): Promise<SiteRecord>;
@@ -19,6 +19,14 @@ export interface StorageAdapter {
 	searchByEmbedding(siteId: string, embedding: number[], limit: number): Promise<PageRecord[]>;
 	deleteStalePagesOlderThan(siteId: string, cutoff: string): Promise<number>;
 
-	recordSuggestionServed(siteId: string, deadUrl: string, suggestedUrls: string[]): Promise<void>;
+	recordSuggestionServed(
+		siteId: string,
+		deadUrl: string,
+		suggestedUrls: string[],
+		scores?: string,
+		matchTypes?: string,
+	): Promise<void>;
 	getStats(siteId: string): Promise<SiteStats>;
+	getSuggestionLogs(siteId: string, limit: number): Promise<SuggestionLog[]>;
+	getMatchQualityStats(siteId: string): Promise<MatchQualityStats>;
 }

--- a/src/storage/postgres.ts
+++ b/src/storage/postgres.ts
@@ -1,5 +1,5 @@
 import { neon, type NeonQueryFunction } from "@neondatabase/serverless";
-import type { PageRecord, SiteRecord, SiteStats } from "../types.js";
+import type { PageRecord, SiteRecord, SiteStats, SuggestionLog, MatchQualityStats } from "../types.js";
 import type { StorageAdapter } from "./interface.js";
 
 type Sql = NeonQueryFunction<false, true>;
@@ -140,10 +140,12 @@ export class PostgresStorage implements StorageAdapter {
 		siteId: string,
 		deadUrl: string,
 		suggestedUrls: string[],
+		scores?: string,
+		matchTypes?: string,
 	): Promise<void> {
 		await this.sql`
-			INSERT INTO suggestion_logs (site_id, dead_url, suggested_urls)
-			VALUES (${siteId}, ${deadUrl}, ${JSON.stringify(suggestedUrls)})
+			INSERT INTO suggestion_logs (site_id, dead_url, suggested_urls, scores, match_types)
+			VALUES (${siteId}, ${deadUrl}, ${JSON.stringify(suggestedUrls)}, ${scores ?? null}, ${matchTypes ?? null})
 		`;
 	}
 
@@ -156,6 +158,49 @@ export class PostgresStorage implements StorageAdapter {
 		return {
 			pageCount: Number(pages.rows[0]?.count ?? 0),
 			suggestionsServed: Number(suggestions.rows[0]?.count ?? 0),
+		};
+	}
+
+	async getSuggestionLogs(siteId: string, limit: number): Promise<SuggestionLog[]> {
+		const { rows } = await this.sql.query(
+			`SELECT dead_url, suggested_urls, scores, match_types, created_at
+			FROM suggestion_logs
+			WHERE site_id = $1
+			ORDER BY created_at DESC
+			LIMIT $2`,
+			[siteId, limit],
+		);
+		return rows.map((row: Record<string, unknown>) => ({
+			deadUrl: row.dead_url as string,
+			suggestedUrls: JSON.parse((row.suggested_urls as string) || "[]"),
+			scores: (row.scores as string) || null,
+			matchTypes: (row.match_types as string) || null,
+			createdAt: String(row.created_at),
+		}));
+	}
+
+	async getMatchQualityStats(siteId: string): Promise<MatchQualityStats> {
+		const { rows } = await this.sql`
+			SELECT
+				COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours') as last_24h,
+				COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '7 days') as last_7d,
+				COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '30 days') as last_30d,
+				COUNT(*) FILTER (WHERE match_types LIKE '%moved%') as moved_count,
+				COUNT(*) FILTER (WHERE match_types LIKE '%similar%') as similar_count,
+				COUNT(*) FILTER (WHERE match_types LIKE '%related%') as related_count
+			FROM suggestion_logs
+			WHERE site_id = ${siteId}
+		`;
+		const row = rows[0] || {};
+		return {
+			last24h: Number(row.last_24h ?? 0),
+			last7d: Number(row.last_7d ?? 0),
+			last30d: Number(row.last_30d ?? 0),
+			matchTypeDistribution: {
+				moved: Number(row.moved_count ?? 0),
+				similar: Number(row.similar_count ?? 0),
+				related: Number(row.related_count ?? 0),
+			},
 		};
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,3 +28,11 @@ export interface SiteStats {
 	pageCount: number;
 	suggestionsServed: number;
 }
+
+export interface AnalysisReport {
+	domain: string;
+	analyzedAt: string;
+	pagesAnalyzed: number;
+	brokenLinks: { sourcePage: string; targetUrl: string }[];
+	orphanPages: string[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,3 +36,26 @@ export interface AnalysisReport {
 	brokenLinks: { sourcePage: string; targetUrl: string }[];
 	orphanPages: string[];
 }
+
+export interface SuggestionLog {
+	deadUrl: string;
+	suggestedUrls: string[];
+	scores: string | null;
+	matchTypes: string | null;
+	createdAt: string;
+}
+
+export interface MatchQualityStats {
+	last24h: number;
+	last7d: number;
+	last30d: number;
+	matchTypeDistribution: { moved: number; similar: number; related: number };
+}
+
+export interface DashboardData {
+	domain: string;
+	pageCount: number;
+	suggestionsServed: number;
+	recentLogs: SuggestionLog[];
+	matchQuality: MatchQualityStats;
+}

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { analyzeSite } from "../src/engine/analyzer.js";
+
+const pages = [
+	{ url: "https://example.com/docs/auth", title: "Auth" },
+	{ url: "https://example.com/docs/billing", title: "Billing" },
+	{ url: "https://example.com/docs/getting-started", title: "Getting Started" },
+];
+
+function makeHtml(links: string[]): string {
+	const anchors = links.map((l) => `<a href="${l}">link</a>`).join("");
+	return `<html><body>${anchors}</body></html>`;
+}
+
+describe("analyzeSite", () => {
+	beforeEach(() => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string) => {
+				if (url === "https://example.com/docs/auth") {
+					return new Response(
+						makeHtml(["/docs/billing", "/docs/nonexistent"]),
+						{ status: 200 },
+					);
+				}
+				if (url === "https://example.com/docs/billing") {
+					return new Response(
+						makeHtml(["/docs/auth", "/docs/getting-started"]),
+						{ status: 200 },
+					);
+				}
+				if (url === "https://example.com/docs/getting-started") {
+					return new Response(
+						makeHtml(["/docs/auth"]),
+						{ status: 200 },
+					);
+				}
+				return new Response("", { status: 404 });
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("should detect broken links", async () => {
+		const report = await analyzeSite(pages, "example.com");
+		expect(report.brokenLinks.length).toBeGreaterThan(0);
+		const broken = report.brokenLinks.find((b) => b.targetUrl.includes("nonexistent"));
+		expect(broken).toBeDefined();
+		expect(broken!.sourcePage).toBe("https://example.com/docs/auth");
+	});
+
+	it("should detect orphan pages", async () => {
+		const pagesWithOrphan = [
+			...pages,
+			{ url: "https://example.com/docs/hidden", title: "Hidden" },
+		];
+		const report = await analyzeSite(pagesWithOrphan, "example.com");
+		expect(report.orphanPages).toContain("https://example.com/docs/hidden");
+	});
+
+	it("should count analyzed pages", async () => {
+		const report = await analyzeSite(pages, "example.com");
+		expect(report.pagesAnalyzed).toBe(3);
+		expect(report.domain).toBe("example.com");
+		expect(report.analyzedAt).toBeTruthy();
+	});
+
+	it("should ignore external links", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				new Response(
+					makeHtml(["https://other.com/page", "/docs/billing"]),
+					{ status: 200 },
+				),
+			),
+		);
+
+		const report = await analyzeSite(pages, "example.com");
+		const external = report.brokenLinks.find((b) => b.targetUrl.includes("other.com"));
+		expect(external).toBeUndefined();
+	});
+
+	it("should handle fetch failures gracefully", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("", { status: 500 })),
+		);
+
+		const report = await analyzeSite(pages, "example.com");
+		expect(report.pagesAnalyzed).toBe(0);
+		expect(report.brokenLinks).toEqual([]);
+	});
+});

--- a/test/matcher.test.ts
+++ b/test/matcher.test.ts
@@ -101,6 +101,38 @@ describe("findSuggestions", () => {
 		expect(urls.some((u) => u.includes("deploy"))).toBe(true);
 	});
 
+	it("should match via stemming (deploy → deployment)", () => {
+		const stemPages = [
+			makePage("https://example.com/docs/deployment", "Deployment Guide"),
+			makePage("https://example.com/docs/monitoring", "Monitoring Guide"),
+			makePage("https://example.com/docs/testing", "Testing Guide"),
+		];
+		const results = findSuggestions("https://example.com/docs/deploy", stemPages);
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0].url).toContain("/deployment");
+	});
+
+	it("should match via stemming (message → messaging)", () => {
+		const stemPages = [
+			makePage("https://example.com/docs/messaging", "Messaging API"),
+			makePage("https://example.com/docs/voice", "Voice API"),
+			makePage("https://example.com/docs/video", "Video API"),
+		];
+		const results = findSuggestions("https://example.com/docs/message", stemPages);
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0].url).toContain("/messaging");
+	});
+
+	it("should match via stemming (organize → organizations)", () => {
+		const stemPages = [
+			makePage("https://example.com/api/organizations", "Organizations API"),
+			makePage("https://example.com/api/users", "Users API"),
+		];
+		const results = findSuggestions("https://example.com/api/organize", stemPages);
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0].url).toContain("/organizations");
+	});
+
 	it("should rank similar paths higher", () => {
 		const results = findSuggestions("https://example.com/docs/v3/billing", pages);
 		expect(results[0].url).toBe("https://example.com/docs/v3/billing");

--- a/test/stemmer.test.ts
+++ b/test/stemmer.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { stemToken } from "../src/engine/stemmer.js";
+
+describe("stemToken", () => {
+	it("should strip -ing suffix", () => {
+		expect(stemToken("messaging")).toBe("messag");
+		expect(stemToken("running")).toBe("runn");
+	});
+
+	it("should strip -ment suffix", () => {
+		expect(stemToken("deployment")).toBe("deploy");
+	});
+
+	it("should strip -ments suffix", () => {
+		expect(stemToken("deployments")).toBe("deploy");
+	});
+
+	it("should strip -izations suffix", () => {
+		expect(stemToken("organizations")).toBe("organize");
+	});
+
+	it("should strip -tion suffix", () => {
+		expect(stemToken("configuration")).toBe("configura");
+	});
+
+	it("should strip -ers suffix", () => {
+		expect(stemToken("workers")).toBe("work");
+	});
+
+	it("should strip -ies → y", () => {
+		expect(stemToken("queries")).toBe("query");
+	});
+
+	it("should strip -es suffix", () => {
+		expect(stemToken("classes")).toBe("class");
+	});
+
+	it("should strip -ed suffix", () => {
+		expect(stemToken("deployed")).toBe("deploy");
+	});
+
+	it("should strip -er suffix", () => {
+		expect(stemToken("worker")).toBe("work");
+	});
+
+	it("should strip -ly suffix", () => {
+		expect(stemToken("quickly")).toBe("quick");
+	});
+
+	it("should strip -s suffix", () => {
+		expect(stemToken("endpoints")).toBe("endpoint");
+	});
+
+	it("should pass through words <= 4 chars", () => {
+		expect(stemToken("api")).toBe("api");
+		expect(stemToken("docs")).toBe("docs");
+		expect(stemToken("v3")).toBe("v3");
+	});
+
+	it("should not strip if stem would be < 3 chars", () => {
+		expect(stemToken("sting")).toBe("sting");
+		expect(stemToken("using")).toBe("using");
+	});
+
+	it("should handle words with no matching suffix", () => {
+		expect(stemToken("deploy")).toBe("deploy");
+		expect(stemToken("auth")).toBe("auth");
+	});
+});


### PR DESCRIPTION
## Summary
- Server-rendered dashboard at `GET /dashboard?key=API_KEY` with dark theme matching existing landing page
- Shows indexed page count, suggestions served, match type distribution (moved/similar/related %), and recent activity table
- Adds `scores` and `match_types` columns to `suggestion_logs` via migration for analytics
- Updates suggest route to log scoring metadata alongside suggestions

## Files changed
- **New:** `migrations/0003_dashboard.sql` — adds columns + index
- **New:** `src/dashboard.ts` — HTML template with stats, distribution, activity table
- **Modified:** `src/types.ts` — `SuggestionLog`, `MatchQualityStats`, `DashboardData` types
- **Modified:** `src/storage/interface.ts` — new `getSuggestionLogs`, `getMatchQualityStats` methods
- **Modified:** `src/storage/postgres.ts` — implements new storage methods
- **Modified:** `src/api/routes/suggest.ts` — passes scores + match types to logging
- **Modified:** `src/index.ts` — dashboard route with API key auth

## Post-deployment
- Run `migrations/0003_dashboard.sql` against prod DB (additive, zero-downtime safe)

## Test plan
- [x] All 69 unit tests pass (`npm test`)
- [ ] Manual: load dashboard in browser, verify stats render
- [ ] Verify API key auth works (invalid key returns 401)
- [ ] Verify key is never rendered in HTML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)