### PR TITLE
Add static link analyzer for broken links and orphans

### DIFF
--- a/src/api/routes/analyze.ts
+++ b/src/api/routes/analyze.ts
@@ -1,0 +1,32 @@
+import { Hono } from "hono";
+import type { PostgresStorage } from "../../storage/postgres.js";
+import { analyzeSite } from "../../engine/analyzer.js";
+
+type Env = { Variables: { storage: PostgresStorage; siteId: string } };
+
+const analyze = new Hono<Env>();
+
+// Analyze a site for broken internal links and orphan pages
+analyze.post("/", async (c) => {
+	const siteId = c.get("siteId");
+	const storage = c.get("storage");
+
+	const site = await storage.getSite(siteId);
+	if (!site) {
+		return c.json({ error: "Site not found" }, 404);
+	}
+
+	const pages = await storage.getPages(siteId);
+	if (pages.length === 0) {
+		return c.json({ error: "No pages indexed for this site" }, 400);
+	}
+
+	const report = await analyzeSite(
+		pages.map((p) => ({ url: p.url, title: p.title })),
+		site.domain,
+	);
+
+	return c.json(report);
+});
+
+export { analyze };

--- a/src/engine/analyzer.ts
+++ b/src/engine/analyzer.ts
@@ -1,0 +1,136 @@
+import type { AnalysisReport } from "../types.js";
+
+interface PageInfo {
+	url: string;
+	title: string;
+}
+
+const BATCH_SIZE = 5;
+const BATCH_DELAY_MS = 200;
+const OVERALL_TIMEOUT_MS = 30_000;
+const FETCH_TIMEOUT_MS = 5_000;
+const USER_AGENT = "Mozilla/5.0 (compatible; agent-404-analyzer/1.0)";
+
+/** Extract internal <a href> links from HTML */
+function extractInternalLinks(html: string, domain: string): string[] {
+	const links: string[] = [];
+	const hrefRe = /<a\s[^>]*href=["']([^"']+)["']/gi;
+	let match: RegExpExecArray | null;
+	while ((match = hrefRe.exec(html)) !== null) {
+		const href = match[1];
+		try {
+			const url = new URL(href, `https://${domain}`);
+			if (url.hostname === domain || url.hostname === `www.${domain}`) {
+				const normalized = `${url.origin}${url.pathname}`.replace(/\/+$/, "");
+				links.push(normalized);
+			}
+		} catch {
+			// skip invalid URLs
+		}
+	}
+	return links;
+}
+
+/** SSRF protection: block private/internal IPs */
+const BLOCKED_PREFIXES = [
+	"localhost", "127.", "0.0.0.0", "10.",
+	"172.16.", "172.17.", "172.18.", "172.19.",
+	"172.20.", "172.21.", "172.22.", "172.23.",
+	"172.24.", "172.25.", "172.26.", "172.27.",
+	"172.28.", "172.29.", "172.30.", "172.31.",
+	"192.168.", "169.254.", "[::1]", "[fc", "[fd",
+];
+
+function isBlockedHost(hostname: string): boolean {
+	const lower = hostname.toLowerCase();
+	return BLOCKED_PREFIXES.some((b) => lower === b || lower.startsWith(b));
+}
+
+async function fetchPageHtml(url: string): Promise<string | null> {
+	try {
+		const parsed = new URL(url);
+		if (isBlockedHost(parsed.hostname)) return null;
+	} catch {
+		return null;
+	}
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+	try {
+		const resp = await fetch(url, {
+			headers: { "User-Agent": USER_AGENT, Accept: "text/html" },
+			signal: controller.signal,
+			redirect: "follow",
+		});
+		if (!resp.ok) return null;
+		return await resp.text();
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Analyze a site's indexed pages for broken internal links and orphan pages.
+ */
+export async function analyzeSite(
+	pages: PageInfo[],
+	domain: string,
+): Promise<AnalysisReport> {
+	const deadline = Date.now() + OVERALL_TIMEOUT_MS;
+	const pageUrlSet = new Set(pages.map((p) => p.url.replace(/\/+$/, "")));
+	const brokenLinks: AnalysisReport["brokenLinks"] = [];
+	const inboundCount = new Map<string, number>();
+
+	// Initialize inbound counts
+	for (const url of pageUrlSet) {
+		inboundCount.set(url, 0);
+	}
+
+	let pagesAnalyzed = 0;
+
+	// Process in batches
+	for (let i = 0; i < pages.length; i += BATCH_SIZE) {
+		if (Date.now() >= deadline) break;
+
+		const batch = pages.slice(i, i + BATCH_SIZE);
+		const results = await Promise.all(batch.map((p) => fetchPageHtml(p.url)));
+
+		for (let j = 0; j < batch.length; j++) {
+			const html = results[j];
+			if (!html) continue;
+			pagesAnalyzed++;
+
+			const links = extractInternalLinks(html, domain);
+			for (const link of links) {
+				if (pageUrlSet.has(link)) {
+					inboundCount.set(link, (inboundCount.get(link) || 0) + 1);
+				} else {
+					brokenLinks.push({ sourcePage: batch[j].url, targetUrl: link });
+				}
+			}
+		}
+
+		if (i + BATCH_SIZE < pages.length && Date.now() < deadline) {
+			await sleep(BATCH_DELAY_MS);
+		}
+	}
+
+	// Orphans = pages with zero inbound links from other indexed pages
+	const orphanPages = [...inboundCount.entries()]
+		.filter(([, count]) => count === 0)
+		.map(([url]) => url);
+
+	return {
+		domain,
+		analyzedAt: new Date().toISOString(),
+		pagesAnalyzed,
+		brokenLinks,
+		orphanPages,
+	};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { pruneStalePages } from "./engine/indexer.js";
 import { buildEmbeddingText, generateBatchEmbeddings } from "./engine/embeddings.js";
 import { landingPageHtml } from "./landing.js";
 import { demoPageHtml } from "./demo.js";
+import { analyze } from "./api/routes/analyze.js";
 
 export type Bindings = {
 	DATABASE_URL: string;
@@ -55,6 +56,7 @@ app.use("*", async (c, next) => {
 app.use("/api/sites", rateLimiter({ windowMs: 60_000, max: 10 }));
 app.use("/api/register", rateLimiter({ windowMs: 60_000, max: 60 }));
 app.use("/api/suggest", rateLimiter({ windowMs: 60_000, max: 60 }));
+app.use("/api/analyze", rateLimiter({ windowMs: 300_000, max: 2 }));
 
 // Landing page
 app.get("/", (c) => c.html(landingPageHtml));
@@ -972,6 +974,9 @@ app.route("/api/register", register);
 
 app.use("/api/suggest", apiKeyAuth());
 app.route("/api/suggest", suggest);
+
+app.use("/api/analyze", apiKeyAuth());
+app.route("/api/analyze", analyze);
 
 // Cron: re-crawl sitemaps + prune stale pages
 app.get("/api/cron", async (c) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,3 +28,11 @@ export interface SiteStats {
 	pageCount: number;
 	suggestionsServed: number;
 }
+
+export interface AnalysisReport {
+	domain: string;
+	analyzedAt: string;
+	pagesAnalyzed: number;
+	brokenLinks: { sourcePage: string; targetUrl: string }[];
+	orphanPages: string[];
+}

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { analyzeSite } from "../src/engine/analyzer.js";
+
+const pages = [
+	{ url: "https://example.com/docs/auth", title: "Auth" },
+	{ url: "https://example.com/docs/billing", title: "Billing" },
+	{ url: "https://example.com/docs/getting-started", title: "Getting Started" },
+];
+
+function makeHtml(links: string[]): string {
+	const anchors = links.map((l) => `<a href="${l}">link</a>`).join("");
+	return `<html><body>${anchors}</body></html>`;
+}
+
+describe("analyzeSite", () => {
+	beforeEach(() => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string) => {
+				if (url === "https://example.com/docs/auth") {
+					return new Response(
+						makeHtml(["/docs/billing", "/docs/nonexistent"]),
+						{ status: 200 },
+					);
+				}
+				if (url === "https://example.com/docs/billing") {
+					return new Response(
+						makeHtml(["/docs/auth", "/docs/getting-started"]),
+						{ status: 200 },
+					);
+				}
+				if (url === "https://example.com/docs/getting-started") {
+					return new Response(
+						makeHtml(["/docs/auth"]),
+						{ status: 200 },
+					);
+				}
+				return new Response("", { status: 404 });
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("should detect broken links", async () => {
+		const report = await analyzeSite(pages, "example.com");
+		expect(report.brokenLinks.length).toBeGreaterThan(0);
+		const broken = report.brokenLinks.find((b) => b.targetUrl.includes("nonexistent"));
+		expect(broken).toBeDefined();
+		expect(broken!.sourcePage).toBe("https://example.com/docs/auth");
+	});
+
+	it("should detect orphan pages", async () => {
+		const pagesWithOrphan = [
+			...pages,
+			{ url: "https://example.com/docs/hidden", title: "Hidden" },
+		];
+		const report = await analyzeSite(pagesWithOrphan, "example.com");
+		expect(report.orphanPages).toContain("https://example.com/docs/hidden");
+	});
+
+	it("should count analyzed pages", async () => {
+		const report = await analyzeSite(pages, "example.com");
+		expect(report.pagesAnalyzed).toBe(3);
+		expect(report.domain).toBe("example.com");
+		expect(report.analyzedAt).toBeTruthy();
+	});
+
+	it("should ignore external links", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				new Response(
+					makeHtml(["https://other.com/page", "/docs/billing"]),
+					{ status: 200 },
+				),
+			),
+		);
+
+		const report = await analyzeSite(pages, "example.com");
+		const external = report.brokenLinks.find((b) => b.targetUrl.includes("other.com"));
+		expect(external).toBeUndefined();
+	});
+
+	it("should handle fetch failures gracefully", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("", { status: 500 })),
+		);
+
+		const report = await analyzeSite(pages, "example.com");
+		expect(report.pagesAnalyzed).toBe(0);
+		expect(report.brokenLinks).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- New `POST /api/analyze` endpoint that crawls indexed pages' HTML to find broken internal links and orphan pages
- Batched fetching (5 at a time, 200ms delay) with 30s overall timeout and partial results on timeout
- SSRF protection blocking private/internal IPs
- Rate limited to 2 requests per 5 minutes

## Files changed
- **New:** `src/engine/analyzer.ts` — core analysis engine
- **New:** `src/api/routes/analyze.ts` — route handler
- **Modified:** `src/types.ts` — `AnalysisReport` interface
- **Modified:** `src/index.ts` — route registration with auth + rate limit
- **New:** `test/analyzer.test.ts` — 5 tests with mocked fetch

## Test plan
- [x] All 74 unit tests pass (`npm test`)
- [ ] Manual: test analyzer endpoint against a registered site
- [ ] Verify SSRF protection blocks private IPs
- [ ] Verify rate limiting works (2 per 5 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)